### PR TITLE
Fix signOut to delete the configured session cookie name

### DIFF
--- a/example/src/routes/_authenticated/account.tsx
+++ b/example/src/routes/_authenticated/account.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { Box, Flex, Heading, Text, TextField } from '@radix-ui/themes';
-import {} from '@tanstack/react-router';
 import { getAuth } from '@workos/authkit-tanstack-react-start';
 
 export const Route = createFileRoute('/_authenticated/account')({

--- a/src/server/server-functions.spec.ts
+++ b/src/server/server-functions.spec.ts
@@ -29,7 +29,7 @@ vi.mock('@workos/authkit-session', () => ({
     const configs: Record<string, any> = {
       clientId: 'test_client_id',
       redirectUri: 'http://test.local/callback',
-      cookieName: 'wos_session',
+      cookieName: 'wos-session',
     };
     return configs[key];
   }),
@@ -158,7 +158,7 @@ describe('Server Functions', () => {
       } catch (error: any) {
         expect(error.message).toBe('REDIRECT');
         expect(error.options.href).toBe(logoutUrl);
-        expect(error.options.headers['Set-Cookie']).toContain('wos_session=');
+        expect(error.options.headers['Set-Cookie']).toContain('wos-session=');
       }
     });
 

--- a/src/server/server-functions.ts
+++ b/src/server/server-functions.ts
@@ -1,6 +1,7 @@
 import { createServerFn, getGlobalStartContext } from '@tanstack/react-start';
 import { getRequest } from '@tanstack/react-start/server';
 import { redirect } from '@tanstack/react-router';
+import { getConfig } from '@workos/authkit-session';
 import { authkit } from './authkit.js';
 import type { User, Impersonator } from '../types.js';
 import type { GetAuthorizationUrlOptions as GetAuthURLOptions } from '@workos/authkit-session';
@@ -56,13 +57,16 @@ export const signOut = createServerFn({ method: 'POST' })
       returnTo: data?.returnTo,
     });
 
+    // Get the configured cookie name from authkit
+    const cookieName = getConfig('cookieName');
+
     // Clear session and redirect to WorkOS logout
     throw redirect({
       href: logoutUrl,
       throw: true,
       reloadDocument: true,
       headers: {
-        'Set-Cookie': `wos_session=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=lax`,
+        'Set-Cookie': `${cookieName}=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=lax`,
       },
     });
   });


### PR DESCRIPTION
## Summary

Fixes issue where `signOut` was hardcoding `wos_session` instead of using the configured cookie name, which defaults to `wos-session`. This caused the actual session cookie to remain after sign-out, leading to auth state confusion.

## Changes

- Import `getConfig` from `@workos/authkit-session`
- Dynamically get cookie name via `getConfig('cookieName')` instead of hardcoding
- Update tests to use correct default cookie name `wos-session` (hyphen, not underscore)
- Remove unused import in example account route

## Testing

Tested in the example app:
1. Sign in and verify `wos-session` cookie is created
2. Sign out
3. Verify `wos-session` cookie is deleted
4. Confirm no auth state confusion after sign-out

Fixes #6