### PR TITLE
chore: remove dotenv from example vite.config

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -30,7 +30,6 @@
     "@types/react-dom": "^19.2.0",
     "@vitejs/plugin-react": "^5.0.4",
     "autoprefixer": "^10.4.20",
-    "dotenv": "^17.2.3",
     "postcss": "^8.5.1",
     "tailwindcss": "^4.1.14",
     "typescript": "^5.9.3",

--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -2,10 +2,6 @@ import { defineConfig } from 'vite';
 import tsConfigPaths from 'vite-tsconfig-paths';
 import { tanstackStart } from '@tanstack/react-start/plugin/vite';
 import viteReact from '@vitejs/plugin-react';
-import * as dotenv from 'dotenv';
-
-// Load .env file
-dotenv.config();
 
 export default defineConfig({
   server: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,9 +106,6 @@ importers:
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.21(postcss@8.5.6)
-      dotenv:
-        specifier: ^17.2.3
-        version: 17.2.3
       postcss:
         specifier: ^8.5.1
         version: 8.5.6
@@ -1981,10 +1978,6 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
-
-  dotenv@17.2.3:
-    resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
-    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -5091,8 +5084,6 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
-
-  dotenv@17.2.3: {}
 
   dunder-proto@1.0.1:
     dependencies:


### PR DESCRIPTION
Removes direct dotenv invocation from the example app's vite.config.ts.

TanStack Start loads .env files automatically, so explicitly calling `dotenv.config()` in the Vite config is unnecessary.