### PR TITLE
change node version in release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           version: 10
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 


### PR DESCRIPTION
This pull request updates the Node.js version used in the release workflow to improve compatibility and leverage the latest features.

Workflow configuration update:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L25-R25): Changed the Node.js version from `18` to `22` in the `setup-node` step for the release workflow.