### PR TITLE
fix: remove unused ensureSignedIn parameter from server actions

### DIFF
--- a/src/client/AuthKitProvider.tsx
+++ b/src/client/AuthKitProvider.tsx
@@ -35,10 +35,10 @@ export function AuthKitProvider({ children, onSessionExpired, initialAuth }: Aut
   const [impersonator, setImpersonator] = useState<Impersonator | undefined>(initialProps.impersonator);
   const [loading, setLoading] = useState(initialAuth ? false : true);
 
-  const getAuth = useCallback(async ({ ensureSignedIn = false }: { ensureSignedIn?: boolean } = {}) => {
+  const getAuth = useCallback(async () => {
     setLoading(true);
     try {
-      const auth = await getAuthAction({ data: { ensureSignedIn } });
+      const auth = await getAuthAction();
       const props = getProps(auth);
       setUser(props.user);
       setSessionId(props.sessionId);
@@ -65,10 +65,10 @@ export function AuthKitProvider({ children, onSessionExpired, initialAuth }: Aut
   }, []);
 
   const refreshAuth = useCallback(
-    async ({ ensureSignedIn = false, organizationId }: { ensureSignedIn?: boolean; organizationId?: string } = {}) => {
+    async ({ organizationId }: { ensureSignedIn?: boolean; organizationId?: string } = {}) => {
       try {
         setLoading(true);
-        const auth = await refreshAuthAction({ data: { ensureSignedIn, organizationId } });
+        const auth = await refreshAuthAction({ data: { organizationId } });
         const props = getProps(auth);
         setUser(props.user);
         setSessionId(props.sessionId);

--- a/src/server/actions.ts
+++ b/src/server/actions.ts
@@ -1,6 +1,6 @@
 import { createServerFn } from '@tanstack/react-start';
 import { getRawAuthFromContext, isAuthConfigured, refreshSession } from './auth-helpers.js';
-import type { NoUserInfo, UserInfo } from './server-functions.js';
+import type { ClientUserInfo, NoUserInfo, UserInfo } from './server-functions.js';
 
 function sanitizeAuthForClient(auth: any): Omit<UserInfo, 'accessToken'> | NoUserInfo {
   if (!auth.user) {
@@ -40,18 +40,16 @@ export const checkSessionAction = createServerFn({ method: 'GET' }).handler(() =
  * Get authentication context. Sanitized for client use (no access token).
  * Can be used to seed the AuthKitProvider with the initial authentication state.
  */
-export const getAuthAction = createServerFn({ method: 'GET' })
-  .inputValidator((options?: { ensureSignedIn?: boolean }) => options)
-  .handler(({ data: options }): Omit<UserInfo, 'accessToken'> | NoUserInfo => {
-    const auth = getRawAuthFromContext();
-    return sanitizeAuthForClient(auth);
-  });
+export const getAuthAction = createServerFn({ method: 'GET' }).handler((): ClientUserInfo | NoUserInfo => {
+  const auth = getRawAuthFromContext();
+  return sanitizeAuthForClient(auth);
+});
 
 /**
  * Refresh authentication session. Sanitized for client use (no access token).
  */
 export const refreshAuthAction = createServerFn({ method: 'POST' })
-  .inputValidator((options?: { ensureSignedIn?: boolean; organizationId?: string }) => options)
+  .inputValidator((options?: { organizationId?: string }) => options)
   .handler(async ({ data: options }): Promise<Omit<UserInfo, 'accessToken'> | NoUserInfo> => {
     const result = await refreshSession(options?.organizationId);
 


### PR DESCRIPTION
## Summary

- Removes unused `ensureSignedIn` parameter from `getAuthAction` and `refreshAuthAction` server actions
- Preserves client-side API for backward compatibility (`useAuth({ ensureSignedIn: true })` still works)
- The parameter was accepted but never acted upon - it didn't trigger any redirect

## Context

The `ensureSignedIn` parameter exists in `authkit-nextjs` where it triggers a server-side redirect to sign-in when there's no session. However, in TanStack Start, server function redirects require special client-side handling, making this pattern problematic.

## Recommended Pattern

For protected routes in TanStack Start, use the layout route pattern instead:

```typescript
// routes/_authenticated.tsx
export const Route = createFileRoute('/_authenticated')({
  loader: async () => {
    const { user } = await getAuth();
    if (!user) {
      throw redirect({ href: await getSignInUrl() });
    }
  },
});
```