### PR TITLE
feat: use npm Trusted Publishers for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ jobs:
   test:
     name: Publish to NPM
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -36,14 +39,10 @@ jobs:
 
       - name: Push Release
         if: ${{ !github.event.release.prerelease }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          pnpm publish --tag latest --access=public --no-git-checks
+          pnpm publish --tag latest --access=public --no-git-checks --provenance
 
       - name: Push Pre-Release
         if: ${{ github.event.release.prerelease }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          pnpm publish --tag next --access=public --no-git-checks
+          pnpm publish --tag next --access=public --no-git-checks --provenance


### PR DESCRIPTION
## Summary
- Switch from long-lived `NPM_TOKEN` secret to OIDC-based authentication
- Add `--provenance` flag for signed build attestations
- Remove `NODE_AUTH_TOKEN` env vars from publish steps

## Why
Improves supply chain security with cryptographic proof of build origin. Trusted Publishers eliminates the need for long-lived secrets that can be leaked or rotated.