### PR TITLE
v0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos/authkit-tanstack-react-start",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "The WorkOS library for TanStack React Start provides convenient helpers for authentication and session management using WorkOS & AuthKit with TanStack React Start.",
   "type": "module",
   "main": "./dist/index.js",
@@ -63,7 +63,7 @@
     "url": "https://github.com/workos/authkit-tanstack-start/issues"
   },
   "dependencies": {
-    "@workos/authkit-session": "0.3.2"
+    "@workos/authkit-session": "0.3.4"
   },
   "peerDependencies": {
     "@tanstack/react-router": ">=1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@workos/authkit-session':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.4
+        version: 0.3.4
     devDependencies:
       '@tanstack/react-router':
         specifier: ^1.141.2
@@ -1560,12 +1560,12 @@ packages:
   '@vitest/utils@4.0.15':
     resolution: {integrity: sha512-HXjPW2w5dxhTD0dLwtYHDnelK3j8sR8cWIaLxr22evTyY6q8pRCjZSmhRWVjBaOVXChQd6AwMzi9pucorXCPZA==}
 
-  '@workos-inc/node@8.0.0-rc.5':
-    resolution: {integrity: sha512-g8mUd9iGFe5sLE7YCPbm/Cb5l5orQsEZ+9yKLq9i0U9H+yqYO/Vvl0KEvRiX3Xxo5AKDVLG1K+3QwlTb/s9/4Q==}
+  '@workos-inc/node@8.0.0':
+    resolution: {integrity: sha512-D8VDfx0GXeiVm8vccAl0rElW7taebRnrteKPJzZwehwzI9W/Usa4qKfmwxj+7Lh1Z1deEocDRCpZpV7ml4GpWQ==}
     engines: {node: '>=20.15.0'}
 
-  '@workos/authkit-session@0.3.2':
-    resolution: {integrity: sha512-+uTD+5S+5CeM/vpSXRP8rLtxx7pmI6RtO/d+Q0v+ITkTmNNoPIaWvXAYIAtV08qmIlHLO40UM6hoQSmEoDWifQ==}
+  '@workos/authkit-session@0.3.4':
+    resolution: {integrity: sha512-lbLP1y8MHWL1Op9athZ3SrzKLcL0+xBVpADCMQLI39mPgSQj+/lopVdOx0Cku96hYnJBOJTLVTK3Zox4FbZl4A==}
     engines: {node: '>=20.0.0'}
 
   acorn@8.15.0:
@@ -4091,14 +4091,14 @@ snapshots:
       '@vitest/pretty-format': 4.0.15
       tinyrainbow: 3.0.3
 
-  '@workos-inc/node@8.0.0-rc.5':
+  '@workos-inc/node@8.0.0':
     dependencies:
       iron-webcrypto: 2.0.0
       jose: 6.1.3
 
-  '@workos/authkit-session@0.3.2':
+  '@workos/authkit-session@0.3.4':
     dependencies:
-      '@workos-inc/node': 8.0.0-rc.5
+      '@workos-inc/node': 8.0.0
       iron-webcrypto: 2.0.0
       jose: 6.1.3
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
+  - '.'
   - example/


### PR DESCRIPTION
## Summary
- Bump version to 0.5.0
- Update `@workos/authkit-session` to 0.3.4 (includes WorkOS Node SDK v8 stable)

## Changes since v0.4.1
- feat: add redirectUri option to middleware (#29)
- docs(readme): clarify sign-out redirect configuration (#42)