### PR TITLE
docs: fix package name references in documentation

### DIFF
--- a/example/src/routes/client.tsx
+++ b/example/src/routes/client.tsx
@@ -94,7 +94,7 @@ function RouteComponent() {
           Client-Side Hooks Demo
         </Heading>
         <Text size="5" align="center" color="gray">
-          This page demonstrates the client-side hooks from <Code>@workos/authkit-tanstack-start/client</Code>
+          This page demonstrates the client-side hooks from <Code>@workos/authkit-tanstack-react-start/client</Code>
         </Text>
         <Callout.Root>
           <Callout.Text>ℹ️ Please sign in to see the client-side hooks in action.</Callout.Text>

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,5 +1,5 @@
 /**
- * @workos/authkit-tanstack-start/client
+ * @workos/authkit-tanstack-react-start/client
  *
  * Client-side hooks for WorkOS AuthKit integration with TanStack Start
  */

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -16,7 +16,7 @@ const MIDDLEWARE_NOT_CONFIGURED_ERROR = `AuthKit middleware is not configured.
 
 Add authkitMiddleware() to your app.tsx file:
 
-import { authkitMiddleware } from '@workos/authkit-tanstack-start';
+import { authkitMiddleware } from '@workos/authkit-tanstack-react-start';
 
 export default createRouter({
   routeTree,

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -21,7 +21,7 @@ export interface AuthKitMiddlewareOptions {
  * @example
  * ```typescript
  * import { createStart } from '@tanstack/react-start';
- * import { authkitMiddleware } from '@workos/authkit-tanstack-start';
+ * import { authkitMiddleware } from '@workos/authkit-tanstack-react-start';
  *
  * export const startInstance = createStart(() => ({
  *   requestMiddleware: [authkitMiddleware()],

--- a/src/server/server-functions.ts
+++ b/src/server/server-functions.ts
@@ -52,7 +52,7 @@ export const getSignOutUrl = createServerFn({ method: 'POST' })
  *
  * @example
  * ```typescript
- * import { signOut } from '@workos/authkit-tanstack-start';
+ * import { signOut } from '@workos/authkit-tanstack-react-start';
  *
  * // In a route loader
  * export const Route = createFileRoute('/logout')({
@@ -134,7 +134,7 @@ export function getAuthFromContext(): UserInfo | NoUserInfo {
  * @example
  * ```typescript
  * // In a route loader
- * import { getAuth } from '@workos/authkit-tanstack-start';
+ * import { getAuth } from '@workos/authkit-tanstack-react-start';
  *
  * export const Route = createFileRoute('/protected')({
  *   loader: async () => {
@@ -249,7 +249,7 @@ export const getSignUpUrl = createServerFn({ method: 'GET' })
  *
  * @example
  * ```typescript
- * import { switchToOrganization } from '@workos/authkit-tanstack-start';
+ * import { switchToOrganization } from '@workos/authkit-tanstack-react-start';
  *
  * const auth = await switchToOrganization({ data: { organizationId: 'org_123' } });
  * ```

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -12,7 +12,7 @@ import type { HandleCallbackOptions } from './types.js';
  * @example
  * ```typescript
  * // Basic usage (no options)
- * import { handleCallbackRoute } from '@workos/authkit-tanstack-start';
+ * import { handleCallbackRoute } from '@workos/authkit-tanstack-react-start';
  *
  * export const Route = createFileRoute('/api/auth/callback')({
  *   server: {
@@ -26,7 +26,7 @@ import type { HandleCallbackOptions } from './types.js';
  * @example
  * ```typescript
  * // With onSuccess hook
- * import { handleCallbackRoute } from '@workos/authkit-tanstack-start';
+ * import { handleCallbackRoute } from '@workos/authkit-tanstack-react-start';
  *
  * export const Route = createFileRoute('/api/auth/callback')({
  *   server: {


### PR DESCRIPTION
## Summary
- Updates import examples from `@workos/authkit-tanstack-start` to the correct npm package name `@workos/authkit-tanstack-react-start`
- Affects JSDoc examples and error messages, not actual runtime imports