### PR TITLE
fix(client): remove useNavigate from AuthKitProvider to avoid SSR warning

### DIFF
--- a/src/client/AuthKitProvider.spec.tsx
+++ b/src/client/AuthKitProvider.spec.tsx
@@ -14,12 +14,6 @@ vi.mock('../server/server-functions', () => ({
   getSignOutUrl: vi.fn(),
 }));
 
-// Mock TanStack Router hooks to avoid warnings
-vi.mock('@tanstack/react-router', () => ({
-  useNavigate: () => vi.fn(),
-  useLocation: () => ({ pathname: '/' }),
-}));
-
 describe('AuthKitProvider', () => {
   const mockUser: User = {
     id: 'user_123',
@@ -39,6 +33,31 @@ describe('AuthKitProvider', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('renders without router context (no useNavigate SSR warning)', async () => {
+    // Regression test for https://github.com/workos/authkit-tanstack-start/issues/57
+    // AuthKitProvider renders as a Wrap component before RouterProvider exists.
+    // It must NOT call useNavigate() during render, or it would trigger:
+    // "useRouter must be used inside a <RouterProvider>"
+    //
+    // Since @tanstack/react-router is not mocked here, any unconditional
+    // useNavigate() call would throw. If this test passes, the provider
+    // does not call useNavigate during render.
+    const { getAuthAction } = await import('../server/actions');
+    vi.mocked(getAuthAction).mockResolvedValue({ user: null });
+
+    // This will throw if AuthKitProvider calls useNavigate() unconditionally,
+    // because there is no RouterProvider wrapping the component.
+    await act(async () => {
+      render(
+        <AuthKitProvider>
+          <div>Rendered without router</div>
+        </AuthKitProvider>,
+      );
+    });
+
+    expect(screen.getByText('Rendered without router')).toBeDefined();
   });
 
   it('renders children', async () => {
@@ -455,7 +474,7 @@ describe('AuthKitProvider', () => {
     });
   });
 
-  it('handles signOut when no session exists (navigates to returnTo)', async () => {
+  it('handles signOut when no session exists (navigates to returnTo via location)', async () => {
     const { getAuthAction } = await import('../server/actions');
     const { getSignOutUrl } = await import('../server/server-functions');
 
@@ -464,30 +483,37 @@ describe('AuthKitProvider', () => {
     // Mock getSignOutUrl to return null URL (no session to terminate)
     vi.mocked(getSignOutUrl).mockResolvedValue({ url: null });
 
-    const mockNavigate = vi.fn();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (vi.mocked(await import('@tanstack/react-router')) as any).useNavigate = () => mockNavigate;
-
-    const TestComponent = () => {
-      const { signOut: handleSignOut } = useAuth();
-      return <button onClick={() => handleSignOut({ returnTo: '/login' })}>Sign Out</button>;
-    };
-
-    render(
-      <AuthKitProvider>
-        <TestComponent />
-      </AuthKitProvider>,
-    );
-
-    await waitFor(() => {
-      expect(screen.getByText('Sign Out')).toBeDefined();
+    // Mock window.location.href
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      value: { ...originalLocation, href: '' },
+      writable: true,
     });
 
-    await act(async () => {
-      fireEvent.click(screen.getByText('Sign Out'));
-    });
+    try {
+      const TestComponent = () => {
+        const { signOut: handleSignOut } = useAuth();
+        return <button onClick={() => handleSignOut({ returnTo: '/login' })}>Sign Out</button>;
+      };
 
-    expect(mockNavigate).toHaveBeenCalledWith({ to: '/login' });
+      render(
+        <AuthKitProvider>
+          <TestComponent />
+        </AuthKitProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Sign Out')).toBeDefined();
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('Sign Out'));
+      });
+
+      expect(window.location.href).toBe('/login');
+    } finally {
+      Object.defineProperty(window, 'location', { value: originalLocation, writable: true });
+    }
   });
 
   it('uses default returnTo when signOut called without options', async () => {
@@ -497,31 +523,38 @@ describe('AuthKitProvider', () => {
     vi.mocked(getAuthAction).mockResolvedValue({ user: mockUser, sessionId: 'session_123' });
     vi.mocked(getSignOutUrl).mockResolvedValue({ url: null });
 
-    const mockNavigate = vi.fn();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (vi.mocked(await import('@tanstack/react-router')) as any).useNavigate = () => mockNavigate;
-
-    const TestComponent = () => {
-      const { signOut: handleSignOut } = useAuth();
-      return <button onClick={() => handleSignOut()}>Sign Out</button>;
-    };
-
-    render(
-      <AuthKitProvider>
-        <TestComponent />
-      </AuthKitProvider>,
-    );
-
-    await waitFor(() => {
-      expect(screen.getByText('Sign Out')).toBeDefined();
+    // Mock window.location.href
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      value: { ...originalLocation, href: '' },
+      writable: true,
     });
 
-    await act(async () => {
-      fireEvent.click(screen.getByText('Sign Out'));
-    });
+    try {
+      const TestComponent = () => {
+        const { signOut: handleSignOut } = useAuth();
+        return <button onClick={() => handleSignOut()}>Sign Out</button>;
+      };
 
-    // Default returnTo is '/'
-    expect(getSignOutUrl).toHaveBeenCalledWith({ data: { returnTo: '/' } });
-    expect(mockNavigate).toHaveBeenCalledWith({ to: '/' });
+      render(
+        <AuthKitProvider>
+          <TestComponent />
+        </AuthKitProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Sign Out')).toBeDefined();
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('Sign Out'));
+      });
+
+      // Default returnTo is '/'
+      expect(getSignOutUrl).toHaveBeenCalledWith({ data: { returnTo: '/' } });
+      expect(window.location.href).toBe('/');
+    } finally {
+      Object.defineProperty(window, 'location', { value: originalLocation, writable: true });
+    }
   });
 });

--- a/src/client/AuthKitProvider.tsx
+++ b/src/client/AuthKitProvider.tsx
@@ -1,5 +1,4 @@
 import { createContext, useCallback, useContext, useEffect, useState } from 'react';
-import { useNavigate } from '@tanstack/react-router';
 import { checkSessionAction, getAuthAction, refreshAuthAction, switchToOrganizationAction } from '../server/actions.js';
 import { getSignOutUrl } from '../server/server-functions.js';
 import type { ClientUserInfo, NoUserInfo } from '../server/server-functions.js';
@@ -23,7 +22,6 @@ const getProps = (auth: ClientUserInfo | NoUserInfo | undefined) => {
 };
 
 export function AuthKitProvider({ children, onSessionExpired, initialAuth }: AuthKitProviderProps) {
-  const navigate = useNavigate();
   const initialProps = getProps(initialAuth);
   const [user, setUser] = useState<User | null>(initialProps.user);
   const [sessionId, setSessionId] = useState<string | undefined>(initialProps.sessionId);
@@ -89,18 +87,15 @@ export function AuthKitProvider({ children, onSessionExpired, initialAuth }: Aut
     [],
   );
 
-  const handleSignOut = useCallback(
-    async ({ returnTo = '/' }: { returnTo?: string } = {}) => {
-      const result = await getSignOutUrl({ data: { returnTo } });
+  const handleSignOut = useCallback(async ({ returnTo = '/' }: { returnTo?: string } = {}) => {
+    const result = await getSignOutUrl({ data: { returnTo } });
 
-      if (result.url) {
-        window.location.href = result.url;
-      } else {
-        navigate({ to: returnTo });
-      }
-    },
-    [navigate],
-  );
+    if (result.url) {
+      window.location.href = result.url;
+    } else {
+      window.location.href = returnTo;
+    }
+  }, []);
 
   const handleSwitchToOrganization = useCallback(async (organizationId: string) => {
     try {


### PR DESCRIPTION
## Summary

`AuthKitProvider` called `useNavigate()` unconditionally at the top of the component body. During SSR with TanStack Start, the `Wrap` component renders before `RouterProvider` context is established, causing repeated `useRouter must be used inside a <RouterProvider>` console warnings.

This PR removes `useNavigate` entirely from `AuthKitProvider`. The `handleSignOut` fallback navigation now uses `window.location.href` assignment instead of TanStack Router's `navigate()`, which is safe since sign-out is always a user-triggered client-side action.

### Changes

- **`src/client/AuthKitProvider.tsx`**: Removed `useNavigate` import and hook call. Replaced `navigate({ to: returnTo })` with `window.location.href = returnTo` in the `handleSignOut` fallback path.
- **`src/client/AuthKitProvider.spec.tsx`**: Removed global `@tanstack/react-router` mock. Added regression test that renders `AuthKitProvider` without `RouterProvider` context (would throw if `useNavigate()` were still called unconditionally). Updated sign-out tests to verify `window.location.href` assignment.

Closes #57

## What was tested

**Automated (176 tests pass):**
- All 16 `AuthKitProvider.spec.tsx` tests pass, including the new regression test `"renders without router context (no useNavigate SSR warning)"`
- `pnpm build` succeeds with no type errors
- No `useNavigate` references remain in source or built `dist/client/` output
- No `@tanstack/react-router` imports in `dist/client/` output

**Manual (Playwright E2E):**
- Started example app on `localhost:3000`
- Navigated to home page and account page
- Console output: 0 warnings (only a harmless favicon 404)
- No `useRouter must be used inside a <RouterProvider>` warning observed

## Manual reproduction steps

To reproduce the bug on `main`:

1. Check out `main` and run `pnpm install && pnpm build`
2. `cd example && pnpm dev`
3. Open `http://localhost:3000` in a browser with DevTools console open
4. **Observe**: Repeated `useRouter must be used inside a <RouterProvider>` warnings in the console during SSR/hydration

To verify the fix on this branch:

1. Check out `fix/issue-57` and run `pnpm install && pnpm build`
2. `cd example && pnpm dev`
3. Open `http://localhost:3000` in a browser with DevTools console open
4. **Observe**: No `useRouter` warnings in the console

## Verification

![verified-no-warnings.png](https://github.com/nicknisi/case-assets/releases/download/assets/verified-no-warnings.png)

## Follow-ups

- `@tanstack/react-router` remains in `peerDependencies` even though the client bundle no longer imports it. This is correct since server files (`src/server/`) still use `redirect` from that package. No action needed.