### PR TITLE
Adopt per-flow PKCE cookies (authkit-session 0.5.1)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,7 +2,7 @@
 
 ## 0.6.0 → 0.7.0
 
-First release with PKCE state binding via `@workos/authkit-session@0.5.0`. The
+First release with PKCE state binding via `@workos/authkit-session@0.5.1`. The
 callback now requires a short-lived verifier cookie that is set during sign-in
 initiation. No public API changed — but the **Sign-in endpoint** in the WorkOS
 dashboard becomes load-bearing.
@@ -76,7 +76,7 @@ sets no verifier cookie at all, so there is nothing to fall back to.
 
 ### Dependency change
 
-`@workos/authkit-session` bumps from `0.3.4` to `0.5.0`. The interim `0.4.0`
+`@workos/authkit-session` bumps from `0.3.4` to `0.5.1`. The interim `0.4.0`
 was never shipped in this adapter. The upstream migration guide covers the
 underlying API and cookie-naming changes:
 <https://github.com/workos/authkit-session/blob/main/MIGRATION.md>.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,82 @@
+# Migration Guide
+
+## 0.6.0 → 0.7.0
+
+First release with PKCE state binding via `@workos/authkit-session@0.5.0`. The
+callback now requires a short-lived verifier cookie that is set during sign-in
+initiation. No public API changed — but the **Sign-in endpoint** in the WorkOS
+dashboard becomes load-bearing.
+
+### No public API changes
+
+`handleCallbackRoute`, `authkitMiddleware`, `authkitLoader`, `createSignIn`,
+`createSignUp`, and the session helpers keep their existing signatures.
+Consumer code does not need to change.
+
+### Required: set the Sign-in endpoint in the WorkOS dashboard
+
+Because the callback now requires a per-flow verifier cookie, any flow that
+reaches the callback URL *without* first going through your sign-in route will
+fail with `PKCECookieMissingError` and return 500.
+
+In the [WorkOS dashboard Redirects page](https://dashboard.workos.com/redirects),
+set the **Sign-in endpoint** (`initiate_login_uri`) to the URL where you call
+`createSignIn()` — e.g. `https://your-app.example/api/auth/sign-in`.
+
+This is the URL WorkOS redirects to for flows it initiates itself:
+
+- Dashboard **impersonation**
+- Some SSO scenarios (IdP-initiated)
+- Session expiry requiring reauthentication
+- `prompt=login`
+
+Without it set, those flows land on your callback without a verifier cookie
+and fail. See the README's [setup instructions](README.md#3-create-sign-in-endpoint)
+for the full route pattern.
+
+> If you already configured the Sign-in endpoint for a previous release, no
+> action is needed — the field is unchanged.
+
+### New cookie on the wire
+
+Each sign-in sets a cookie named `wos-auth-verifier-<hash>`, where `<hash>` is
+an 8-character FNV-1a hex suffix derived from the OAuth `state`. One cookie
+per concurrent flow, so multi-tab sign-ins no longer clobber each other.
+
+Attributes:
+
+- `HttpOnly`
+- `SameSite=Lax` by default; `SameSite=None; Secure` when `cookieSameSite` is
+  configured as `'none'` (iframe / embed flows)
+- `Secure` — inferred from the redirect URI's protocol; fail-closed to `true`
+- `Max-Age=600` (10 minutes)
+- `Path=/`
+- `Domain` — set only if `cookieDomain` is configured
+
+If an edge proxy, WAF, CDN, or cookie policy filters by name, allow the
+`wos-auth-verifier-` prefix.
+
+### Rolling-deploy caveat
+
+During an upgrade from 0.6.0 to 0.7.0, OAuth flows that **start on an old pod**
+(no verifier cookie) **and complete on a new pod** (verifier cookie required)
+will fail once with 500 and need a retry.
+
+Exposure is narrow: a user is only affected if they click sign-in on the old
+pod and land back on the callback against the new pod. That window is the time
+they spend on the WorkOS sign-in page — typically 10–60 seconds.
+
+Two mitigations:
+
+- Drain traffic before the deploy.
+- Accept the retry cost. Users retry and succeed on the new pod.
+
+A legacy-cookie-name fallback is not useful: 0.6.0 (on `authkit-session@0.3.4`)
+sets no verifier cookie at all, so there is nothing to fall back to.
+
+### Dependency change
+
+`@workos/authkit-session` bumps from `0.3.4` to `0.5.0`. The interim `0.4.0`
+was never shipped in this adapter. The upstream migration guide covers the
+underlying API and cookie-naming changes:
+<https://github.com/workos/authkit-session/blob/main/MIGRATION.md>.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -16,7 +16,7 @@ Consumer code does not need to change.
 ### Required: set the Sign-in endpoint in the WorkOS dashboard
 
 Because the callback now requires a per-flow verifier cookie, any flow that
-reaches the callback URL *without* first going through your sign-in route will
+reaches the callback URL _without_ first going through your sign-in route will
 fail with `PKCECookieMissingError` and return 500.
 
 In the [WorkOS dashboard Redirects page](https://dashboard.workos.com/redirects),

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "url": "https://github.com/workos/authkit-tanstack-start/issues"
   },
   "dependencies": {
-    "@workos/authkit-session": "^0.5.0"
+    "@workos/authkit-session": "0.5.0"
   },
   "peerDependencies": {
     "@tanstack/react-router": ">=1.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "url": "https://github.com/workos/authkit-tanstack-start/issues"
   },
   "dependencies": {
-    "@workos/authkit-session": "0.4.0"
+    "@workos/authkit-session": "^0.5.0"
   },
   "peerDependencies": {
     "@tanstack/react-router": ">=1.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "url": "https://github.com/workos/authkit-tanstack-start/issues"
   },
   "dependencies": {
-    "@workos/authkit-session": "~0.5.1"
+    "@workos/authkit-session": "^0.5.1"
   },
   "peerDependencies": {
     "@tanstack/react-router": ">=1.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "url": "https://github.com/workos/authkit-tanstack-start/issues"
   },
   "dependencies": {
-    "@workos/authkit-session": "0.5.0"
+    "@workos/authkit-session": "0.5.1"
   },
   "peerDependencies": {
     "@tanstack/react-router": ">=1.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "url": "https://github.com/workos/authkit-tanstack-start/issues"
   },
   "dependencies": {
-    "@workos/authkit-session": "0.5.1"
+    "@workos/authkit-session": "~0.5.1"
   },
   "peerDependencies": {
     "@tanstack/react-router": ">=1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@workos/authkit-session':
-        specifier: ^0.5.0
+        specifier: 0.5.0
         version: 0.5.0(typescript@5.9.3)
     devDependencies:
       '@tanstack/react-router':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@workos/authkit-session':
-        specifier: 0.5.0
-        version: 0.5.0(typescript@5.9.3)
+        specifier: 0.5.1
+        version: 0.5.1(typescript@5.9.3)
     devDependencies:
       '@tanstack/react-router':
         specifier: ^1.154.8
@@ -2030,8 +2030,8 @@ packages:
     resolution: {integrity: sha512-NgQKHpwh8AbT4KvAsW91Y+4f4jja2IvFPQ5atcy5NUxUMVRgXzRFEee3erawfXrTmiCVqJjd9PljHySKBXmHKQ==}
     engines: {node: '>=20.15.0'}
 
-  '@workos/authkit-session@0.5.0':
-    resolution: {integrity: sha512-HVkvZc0vrMKt46AGUHYTzb7et2YncqkArp5SK5ULVKlPA3dbFFHhIbnuXyoyX8+Mbihq1430R4x/9RM4U9438Q==}
+  '@workos/authkit-session@0.5.1':
+    resolution: {integrity: sha512-4nyHhxEfztJmmruMhefmxu/b2ElzswjlUZH/fub1GFXtLN1RNmT552L/VbV0by5ailiJYJ3gk7LJQ61obKHZLw==}
     engines: {node: '>=20.0.0'}
 
   acorn@8.15.0:
@@ -4774,7 +4774,7 @@ snapshots:
     dependencies:
       eventemitter3: 5.0.4
 
-  '@workos/authkit-session@0.5.0(typescript@5.9.3)':
+  '@workos/authkit-session@0.5.1(typescript@5.9.3)':
     dependencies:
       '@workos-inc/node': 8.13.0
       iron-webcrypto: 2.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@workos/authkit-session':
-        specifier: ~0.5.1
+        specifier: ^0.5.1
         version: 0.5.1(typescript@5.9.3)
     devDependencies:
       '@tanstack/react-router':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@workos/authkit-session':
-        specifier: 0.5.1
+        specifier: ~0.5.1
         version: 0.5.1(typescript@5.9.3)
     devDependencies:
       '@tanstack/react-router':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@workos/authkit-session':
-        specifier: 0.4.0
-        version: 0.4.0(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(typescript@5.9.3)
     devDependencies:
       '@tanstack/react-router':
         specifier: ^1.154.8
@@ -2030,8 +2030,8 @@ packages:
     resolution: {integrity: sha512-NgQKHpwh8AbT4KvAsW91Y+4f4jja2IvFPQ5atcy5NUxUMVRgXzRFEee3erawfXrTmiCVqJjd9PljHySKBXmHKQ==}
     engines: {node: '>=20.15.0'}
 
-  '@workos/authkit-session@0.4.0':
-    resolution: {integrity: sha512-s6wwsUZFlY4cvudouKAD7oRQSYAaeBblCafDu1HZhxsnhCQ/ddSsr4OjrTurmckGC6Xsph7Mm7uEe+++QOaTvQ==}
+  '@workos/authkit-session@0.5.0':
+    resolution: {integrity: sha512-HVkvZc0vrMKt46AGUHYTzb7et2YncqkArp5SK5ULVKlPA3dbFFHhIbnuXyoyX8+Mbihq1430R4x/9RM4U9438Q==}
     engines: {node: '>=20.0.0'}
 
   acorn@8.15.0:
@@ -4774,7 +4774,7 @@ snapshots:
     dependencies:
       eventemitter3: 5.0.4
 
-  '@workos/authkit-session@0.4.0(typescript@5.9.3)':
+  '@workos/authkit-session@0.5.0(typescript@5.9.3)':
     dependencies:
       '@workos-inc/node': 8.13.0
       iron-webcrypto: 2.0.0

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,8 @@
     ".": {
       "release-type": "node",
       "changelog-path": "CHANGELOG.md",
-      "versioning": "default"
+      "versioning": "default",
+      "bump-minor-pre-major": true
     }
   }
 }

--- a/src/server/server-functions.spec.ts
+++ b/src/server/server-functions.spec.ts
@@ -1,14 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getPKCECookieNameForState } from '@workos/authkit-session';
 
 // Set up all mocks before any imports that use them
 vi.mock('@tanstack/react-start/server', () => ({
   getRequest: vi.fn(() => new Request('http://test.local')),
 }));
 
+const SEALED_STATE_FIXTURE = 'sealed-blob-abc';
+const PKCE_COOKIE_NAME = getPKCECookieNameForState(SEALED_STATE_FIXTURE);
+
 const authorizationResult = (url: string) => ({
   url,
   headers: {
-    'Set-Cookie': 'wos-auth-verifier=sealed-blob-abc; Path=/; HttpOnly; SameSite=Lax; Max-Age=600; Secure',
+    'Set-Cookie': `${PKCE_COOKIE_NAME}=${SEALED_STATE_FIXTURE}; Path=/; HttpOnly; SameSite=Lax; Max-Age=600; Secure`,
   },
 });
 
@@ -52,16 +56,20 @@ vi.mock('@tanstack/react-router', () => ({
   },
 }));
 
-vi.mock('@workos/authkit-session', () => ({
-  getConfig: vi.fn((key: string) => {
-    const configs: Record<string, any> = {
-      clientId: 'test_client_id',
-      redirectUri: 'http://test.local/callback',
-      cookieName: 'wos-session',
-    };
-    return configs[key];
-  }),
-}));
+vi.mock('@workos/authkit-session', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@workos/authkit-session')>();
+  return {
+    ...actual,
+    getConfig: vi.fn((key: string) => {
+      const configs: Record<string, any> = {
+        clientId: 'test_client_id',
+        redirectUri: 'http://test.local/callback',
+        cookieName: 'wos-session',
+      };
+      return configs[key];
+    }),
+  };
+});
 
 // Mock global context for middleware pattern
 let mockAuthContext: any = null;
@@ -509,13 +517,16 @@ describe('Server Functions', () => {
 
     cases.forEach(({ name, call, mockFn, url }) => {
       describe(name, () => {
-        it('writes Set-Cookie with wos-auth-verifier exactly once', async () => {
+        it('writes Set-Cookie with the derived PKCE cookie name exactly once', async () => {
           mockFn().mockResolvedValue(authorizationResult(url));
 
           await call();
 
           expect(mockSetPendingHeader).toHaveBeenCalledTimes(1);
-          expect(mockSetPendingHeader).toHaveBeenCalledWith('Set-Cookie', expect.stringMatching(/^wos-auth-verifier=/));
+          expect(mockSetPendingHeader).toHaveBeenCalledWith(
+            'Set-Cookie',
+            expect.stringMatching(new RegExp(`^${PKCE_COOKIE_NAME}=`)),
+          );
         });
 
         it('returns only the URL (no sealedState leak)', async () => {

--- a/src/server/server.spec.ts
+++ b/src/server/server.spec.ts
@@ -9,7 +9,10 @@ const mockWithAuth = vi.fn();
 const mockCreateSignIn = vi.fn();
 type ClearPendingVerifierResult = { response?: Response; headers?: { 'Set-Cookie'?: string | string[] } };
 const mockClearPendingVerifier = vi.fn(
-  async (_response: Response, options: { state: string; redirectUri?: string }): Promise<ClearPendingVerifierResult> => {
+  async (
+    _response: Response,
+    options: { state: string; redirectUri?: string },
+  ): Promise<ClearPendingVerifierResult> => {
     const name = getPKCECookieNameForState(options.state);
     return {
       headers: {
@@ -67,9 +70,7 @@ describe('handleCallbackRoute', () => {
 
   describe('missing code', () => {
     it('returns 400 with generic body and state-derived delete-cookie header when state present', async () => {
-      const request = new Request(
-        `http://example.com/callback?state=${encodeURIComponent(SEALED_STATE)}`,
-      );
+      const request = new Request(`http://example.com/callback?state=${encodeURIComponent(SEALED_STATE)}`);
       const response = await handleCallbackRoute()({ request });
 
       expect(response.status).toBe(400);
@@ -80,9 +81,7 @@ describe('handleCallbackRoute', () => {
     });
 
     it('calls onError hook when provided', async () => {
-      const request = new Request(
-        `http://example.com/callback?state=${encodeURIComponent(SEALED_STATE)}`,
-      );
+      const request = new Request(`http://example.com/callback?state=${encodeURIComponent(SEALED_STATE)}`);
       const onError = vi.fn().mockReturnValue(new Response('Custom error', { status: 403 }));
 
       const response = await handleCallbackRoute({ onError })({ request });
@@ -239,9 +238,7 @@ describe('handleCallbackRoute', () => {
 
   describe('error path', () => {
     it('returns 500 with generic body on handleCallback failure', async () => {
-      const request = new Request(
-        `http://example.com/callback?code=invalid&state=${encodeURIComponent(SEALED_STATE)}`,
-      );
+      const request = new Request(`http://example.com/callback?code=invalid&state=${encodeURIComponent(SEALED_STATE)}`);
       mockHandleCallback.mockRejectedValue(new Error('Invalid code'));
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -258,9 +255,7 @@ describe('handleCallbackRoute', () => {
     });
 
     it('calls onError with the underlying error and appends delete-cookie', async () => {
-      const request = new Request(
-        `http://example.com/callback?code=invalid&state=${encodeURIComponent(SEALED_STATE)}`,
-      );
+      const request = new Request(`http://example.com/callback?code=invalid&state=${encodeURIComponent(SEALED_STATE)}`);
       const err = new Error('Auth failed');
       mockHandleCallback.mockRejectedValue(err);
       const onError = vi.fn().mockReturnValue(
@@ -291,9 +286,7 @@ describe('handleCallbackRoute', () => {
       mutatedResponse.headers.append('Set-Cookie', scopedDelete);
       mockClearPendingVerifier.mockResolvedValueOnce({ response: mutatedResponse });
 
-      const request = new Request(
-        `http://example.com/callback?state=${encodeURIComponent(SEALED_STATE)}`,
-      );
+      const request = new Request(`http://example.com/callback?state=${encodeURIComponent(SEALED_STATE)}`);
       const response = await handleCallbackRoute()({ request });
 
       expect(response.status).toBe(400);
@@ -306,9 +299,7 @@ describe('handleCallbackRoute', () => {
       // for the correct per-flow name.
       mockRedirectUriFromContext = 'https://app.example.com/custom/callback';
 
-      const request = new Request(
-        `http://example.com/callback?state=${encodeURIComponent(SEALED_STATE)}`,
-      );
+      const request = new Request(`http://example.com/callback?state=${encodeURIComponent(SEALED_STATE)}`);
       await handleCallbackRoute()({ request });
 
       expect(mockClearPendingVerifier).toHaveBeenCalledWith(expect.any(Response), {
@@ -320,9 +311,7 @@ describe('handleCallbackRoute', () => {
     it('passes only state when middleware context has no redirectUri override', async () => {
       mockRedirectUriFromContext = undefined;
 
-      const request = new Request(
-        `http://example.com/callback?state=${encodeURIComponent(SEALED_STATE)}`,
-      );
+      const request = new Request(`http://example.com/callback?state=${encodeURIComponent(SEALED_STATE)}`);
       await handleCallbackRoute()({ request });
 
       expect(mockClearPendingVerifier).toHaveBeenCalledWith(expect.any(Response), { state: SEALED_STATE });
@@ -353,9 +342,7 @@ describe('handleCallbackRoute', () => {
   describe('state-derived delete headers', () => {
     it('emits a delete header whose cookie name matches getPKCECookieNameForState(state) when state is present', async () => {
       const expected = getPKCECookieNameForState(SEALED_STATE);
-      const request = new Request(
-        `https://app.example/callback?code=bad&state=${encodeURIComponent(SEALED_STATE)}`,
-      );
+      const request = new Request(`https://app.example/callback?code=bad&state=${encodeURIComponent(SEALED_STATE)}`);
       // Force the error path so errorResponse runs. `code=bad` with the mock
       // rejecting triggers the catch branch.
       mockHandleCallback.mockRejectedValue(new Error('boom'));

--- a/src/server/server.spec.ts
+++ b/src/server/server.spec.ts
@@ -1,16 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getPKCECookieNameForState } from '@workos/authkit-session';
+
+const SEALED_STATE = 'sealed-state-fixture';
+const PKCE_COOKIE_NAME = getPKCECookieNameForState(SEALED_STATE);
 
 const mockHandleCallback = vi.fn();
 const mockWithAuth = vi.fn();
 const mockCreateSignIn = vi.fn();
 type ClearPendingVerifierResult = { response?: Response; headers?: { 'Set-Cookie'?: string | string[] } };
 const mockClearPendingVerifier = vi.fn(
-  async (): Promise<ClearPendingVerifierResult> => ({
-    headers: {
-      'Set-Cookie':
-        'wos-auth-verifier=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
-    },
-  }),
+  async (_response: Response, options?: { state: string; redirectUri?: string }): Promise<ClearPendingVerifierResult> => {
+    const name = options?.state ? getPKCECookieNameForState(options.state) : 'wos-auth-verifier';
+    return {
+      headers: {
+        'Set-Cookie': `${name}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT`,
+      },
+    };
+  },
 );
 
 let mockGetAuthkitImpl: () => Promise<any>;
@@ -60,19 +66,23 @@ describe('handleCallbackRoute', () => {
   });
 
   describe('missing code', () => {
-    it('returns 400 with generic body and delete-cookie header', async () => {
-      const request = new Request('http://example.com/callback');
+    it('returns 400 with generic body and state-derived delete-cookie header when state present', async () => {
+      const request = new Request(
+        `http://example.com/callback?state=${encodeURIComponent(SEALED_STATE)}`,
+      );
       const response = await handleCallbackRoute()({ request });
 
       expect(response.status).toBe(400);
       const body = await response.json();
       expect(body.error.message).toBe('Authentication failed');
       expect(body.error).not.toHaveProperty('details');
-      expect(response.headers.getSetCookie()).toEqual([expect.stringContaining('wos-auth-verifier=')]);
+      expect(response.headers.getSetCookie()).toEqual([expect.stringContaining(`${PKCE_COOKIE_NAME}=`)]);
     });
 
     it('calls onError hook when provided', async () => {
-      const request = new Request('http://example.com/callback');
+      const request = new Request(
+        `http://example.com/callback?state=${encodeURIComponent(SEALED_STATE)}`,
+      );
       const onError = vi.fn().mockReturnValue(new Response('Custom error', { status: 403 }));
 
       const response = await handleCallbackRoute({ onError })({ request });
@@ -80,7 +90,7 @@ describe('handleCallbackRoute', () => {
       expect(onError).toHaveBeenCalledWith({ error: expect.any(Error), request });
       expect(response.status).toBe(403);
       expect(await response.text()).toBe('Custom error');
-      expect(response.headers.getSetCookie().some((c) => c.startsWith('wos-auth-verifier='))).toBe(true);
+      expect(response.headers.getSetCookie().some((c) => c.startsWith(`${PKCE_COOKIE_NAME}=`))).toBe(true);
     });
   });
 
@@ -227,7 +237,9 @@ describe('handleCallbackRoute', () => {
 
   describe('error path', () => {
     it('returns 500 with generic body on handleCallback failure', async () => {
-      const request = new Request('http://example.com/callback?code=invalid');
+      const request = new Request(
+        `http://example.com/callback?code=invalid&state=${encodeURIComponent(SEALED_STATE)}`,
+      );
       mockHandleCallback.mockRejectedValue(new Error('Invalid code'));
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -238,13 +250,15 @@ describe('handleCallbackRoute', () => {
       expect(body.error.message).toBe('Authentication failed');
       expect(body.error.description).toContain("Couldn't sign in");
       expect(body.error).not.toHaveProperty('details');
-      expect(response.headers.getSetCookie().some((c) => c.startsWith('wos-auth-verifier='))).toBe(true);
+      expect(response.headers.getSetCookie().some((c) => c.startsWith(`${PKCE_COOKIE_NAME}=`))).toBe(true);
 
       consoleSpy.mockRestore();
     });
 
     it('calls onError with the underlying error and appends delete-cookie', async () => {
-      const request = new Request('http://example.com/callback?code=invalid');
+      const request = new Request(
+        `http://example.com/callback?code=invalid&state=${encodeURIComponent(SEALED_STATE)}`,
+      );
       const err = new Error('Auth failed');
       mockHandleCallback.mockRejectedValue(err);
       const onError = vi.fn().mockReturnValue(
@@ -261,7 +275,7 @@ describe('handleCallbackRoute', () => {
       expect(response.status).toBe(418);
       expect(response.headers.get('X-Custom')).toBe('preserved');
       expect(await response.text()).toBe('Custom error page');
-      expect(response.headers.getSetCookie().some((c) => c.startsWith('wos-auth-verifier='))).toBe(true);
+      expect(response.headers.getSetCookie().some((c) => c.startsWith(`${PKCE_COOKIE_NAME}=`))).toBe(true);
 
       consoleSpy.mockRestore();
     });
@@ -269,50 +283,53 @@ describe('handleCallbackRoute', () => {
     it('reads verifier-delete header from clearPendingVerifier response when headers bag is empty', async () => {
       // The real adapter's storage override returns `{ response }` with the
       // Set-Cookie attached to the response, never populating the headers
-      // bag. The static fallback would lose per-request `redirectUri`-scoped
-      // Path. Simulate that shape and assert the delete rides through.
-      const scopedDelete =
-        'wos-auth-verifier=; Path=/custom/callback; HttpOnly; SameSite=Lax; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT';
+      // bag. Simulate that shape and assert the delete rides through.
+      const scopedDelete = `${PKCE_COOKIE_NAME}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT`;
       const mutatedResponse = new Response();
       mutatedResponse.headers.append('Set-Cookie', scopedDelete);
       mockClearPendingVerifier.mockResolvedValueOnce({ response: mutatedResponse });
 
-      const request = new Request('http://example.com/callback');
+      const request = new Request(
+        `http://example.com/callback?state=${encodeURIComponent(SEALED_STATE)}`,
+      );
       const response = await handleCallbackRoute()({ request });
 
       expect(response.status).toBe(400);
       expect(response.headers.getSetCookie()).toEqual([scopedDelete]);
     });
 
-    it('forwards middleware-scoped redirectUri to clearPendingVerifier so Path matches the set cookie', async () => {
-      // The test above asserts the *extracted* header propagates, but not
-      // that the adapter computed the correct Path. This one proves we pass
-      // the per-request `redirectUri` from middleware context into upstream
-      // so the delete cookie's Path matches what `createSignIn` originally
-      // set. Without this, a failed callback after
-      // `authkitMiddleware({ redirectUri })` would emit a `Path=/` delete
-      // that doesn't match the scoped cookie the browser actually holds.
+    it('forwards middleware-scoped redirectUri and state to clearPendingVerifier', async () => {
+      // Proves we pass the per-request `redirectUri` from middleware context
+      // and the OAuth `state` into upstream so the delete cookie is computed
+      // for the correct per-flow name.
       mockRedirectUriFromContext = 'https://app.example.com/custom/callback';
 
-      const request = new Request('http://example.com/callback');
+      const request = new Request(
+        `http://example.com/callback?state=${encodeURIComponent(SEALED_STATE)}`,
+      );
       await handleCallbackRoute()({ request });
 
       expect(mockClearPendingVerifier).toHaveBeenCalledWith(expect.any(Response), {
+        state: SEALED_STATE,
         redirectUri: 'https://app.example.com/custom/callback',
       });
     });
 
-    it('passes no options when middleware context has no redirectUri override', async () => {
+    it('passes only state when middleware context has no redirectUri override', async () => {
       mockRedirectUriFromContext = undefined;
 
-      const request = new Request('http://example.com/callback');
+      const request = new Request(
+        `http://example.com/callback?state=${encodeURIComponent(SEALED_STATE)}`,
+      );
       await handleCallbackRoute()({ request });
 
-      expect(mockClearPendingVerifier).toHaveBeenCalledWith(expect.any(Response), undefined);
+      expect(mockClearPendingVerifier).toHaveBeenCalledWith(expect.any(Response), { state: SEALED_STATE });
     });
 
-    it('emits static fallback delete-cookies when getAuthkit() rejects', async () => {
-      const request = new Request('http://example.com/callback?code=auth_123');
+    it('emits state-derived delete-cookies when getAuthkit() rejects and state is present', async () => {
+      const request = new Request(
+        `http://example.com/callback?code=auth_123&state=${encodeURIComponent(SEALED_STATE)}`,
+      );
       mockGetAuthkitImpl = () => Promise.reject(new Error('Config missing'));
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -321,12 +338,39 @@ describe('handleCallbackRoute', () => {
       expect(response.status).toBe(500);
       const setCookies = response.headers.getSetCookie();
       expect(setCookies).toHaveLength(2);
+      expect(setCookies.every((c) => c.startsWith(`${PKCE_COOKIE_NAME}=`))).toBe(true);
       expect(setCookies[0]).toContain('SameSite=Lax');
       expect(setCookies[1]).toContain('SameSite=None');
       expect(setCookies[1]).toContain('Secure');
       expect(setCookies.every((c) => c.includes('Max-Age=0'))).toBe(true);
 
       consoleSpy.mockRestore();
+    });
+  });
+
+  describe('state-derived delete headers', () => {
+    it('emits a delete header whose cookie name matches getPKCECookieNameForState(state) when state is present', async () => {
+      const expected = getPKCECookieNameForState(SEALED_STATE);
+      const request = new Request(
+        `https://app.example/callback?code=bad&state=${encodeURIComponent(SEALED_STATE)}`,
+      );
+      // Force the error path so errorResponse runs. `code=bad` with the mock
+      // rejecting triggers the catch branch.
+      mockHandleCallback.mockRejectedValue(new Error('boom'));
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const res = await handleCallbackRoute()({ request });
+      const setCookies = res.headers.getSetCookie();
+      expect(setCookies.some((c) => c.startsWith(`${expected}=`))).toBe(true);
+
+      consoleSpy.mockRestore();
+    });
+
+    it('emits no Set-Cookie delete when state is absent', async () => {
+      const request = new Request('https://app.example/callback'); // no code, no state
+      const res = await handleCallbackRoute()({ request });
+      const setCookies = res.headers.getSetCookie();
+      expect(setCookies.some((c) => c.includes('wos-auth-verifier'))).toBe(false);
     });
   });
 });

--- a/src/server/server.spec.ts
+++ b/src/server/server.spec.ts
@@ -9,8 +9,8 @@ const mockWithAuth = vi.fn();
 const mockCreateSignIn = vi.fn();
 type ClearPendingVerifierResult = { response?: Response; headers?: { 'Set-Cookie'?: string | string[] } };
 const mockClearPendingVerifier = vi.fn(
-  async (_response: Response, options?: { state: string; redirectUri?: string }): Promise<ClearPendingVerifierResult> => {
-    const name = options?.state ? getPKCECookieNameForState(options.state) : 'wos-auth-verifier';
+  async (_response: Response, options: { state: string; redirectUri?: string }): Promise<ClearPendingVerifierResult> => {
+    const name = getPKCECookieNameForState(options.state);
     return {
       headers: {
         'Set-Cookie': `${name}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT`,
@@ -133,8 +133,10 @@ describe('handleCallbackRoute', () => {
     });
 
     it('passes code and state to authkit.handleCallback without a cookieValue arg', async () => {
+      const sealedValue = 'sealed-abc-123';
+      const cookieName = getPKCECookieNameForState('s');
       const request = new Request('http://example.com/callback?code=auth_123&state=s', {
-        headers: { cookie: 'wos-auth-verifier=sealed-abc-123' },
+        headers: { cookie: `${cookieName}=${sealedValue}` },
       });
       mockHandleCallback.mockResolvedValue(successResult());
 
@@ -161,7 +163,7 @@ describe('handleCallbackRoute', () => {
       const request = new Request('http://example.com/callback?code=auth_123');
       mockHandleCallback.mockResolvedValue({
         headers: {
-          'Set-Cookie': ['wos-session=abc123', 'wos-auth-verifier=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax'],
+          'Set-Cookie': ['wos-session=abc123', `${PKCE_COOKIE_NAME}=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax`],
         },
         returnPathname: '/',
         state: undefined,
@@ -172,7 +174,7 @@ describe('handleCallbackRoute', () => {
 
       const setCookies = response.headers.getSetCookie();
       expect(setCookies.some((c) => c.startsWith('wos-session=abc123'))).toBe(true);
-      expect(setCookies.some((c) => c.startsWith('wos-auth-verifier='))).toBe(true);
+      expect(setCookies.some((c) => c.startsWith(`${PKCE_COOKIE_NAME}=`))).toBe(true);
       expect(setCookies).toHaveLength(2);
     });
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,13 +1,22 @@
-import type { HeadersBag } from '@workos/authkit-session';
+import { getPKCECookieNameForState, type HeadersBag } from '@workos/authkit-session';
 import { getAuthkit } from './authkit-loader.js';
 import { getRedirectUriFromContext } from './auth-helpers.js';
 import { emitHeadersFrom } from './headers-bag.js';
 import type { HandleCallbackOptions } from './types.js';
 
-const STATIC_FALLBACK_DELETE_HEADERS: readonly string[] = [
-  'wos-auth-verifier=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
-  'wos-auth-verifier=; Path=/; HttpOnly; SameSite=None; Secure; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
-];
+/**
+ * Build Set-Cookie headers that delete the per-flow PKCE verifier
+ * cookie identified by `state`. When `state` is absent (malformed
+ * callback), return an empty list — the 10-minute TTL handles orphans.
+ */
+function deleteHeadersForState(state: string | null): readonly string[] {
+  if (!state) return [];
+  const name = getPKCECookieNameForState(state);
+  return [
+    `${name}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT`,
+    `${name}=; Path=/; HttpOnly; SameSite=None; Secure; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT`,
+  ];
+}
 
 /**
  * Creates a callback route handler for OAuth authentication.
@@ -56,35 +65,38 @@ export function handleCallbackRoute(options: HandleCallbackOptions = {}) {
 }
 
 /**
- * Extract the `Set-Cookie` header(s) produced by `authkit.clearPendingVerifier()`
- * so we can attach them to whatever response we emit on an error path.
+ * Extract the `Set-Cookie` header(s) produced by
+ * `authkit.clearPendingVerifier()` for the flow identified by `state`.
  *
- * Two things matter here:
- *   1. The delete cookie's `Path` must match whatever `redirectUri` was used
- *      to set it. `authkitMiddleware({ redirectUri })` scopes the verifier
- *      cookie to that URI's path — we pass the same override to
- *      `clearPendingVerifier` so the delete targets the same `Path`.
- *   2. This adapter's storage overrides `applyHeaders`, so `clearCookie`
- *      returns `{ response }` with the `Set-Cookie` attached to the
- *      response — the `headers` bag is empty in that path. Prefer reading
- *      from the response, fall back to the headers bag, then to the static
- *      delete as a last resort.
+ * Delete matching is on (name, domain, path); `path` is always `/`
+ * for PKCE cookies in authkit-session (see `getPKCECookieOptions`).
+ * When authkit setup itself failed or `clearPendingVerifier` throws,
+ * fall back to a state-derived header pair that covers both
+ * SameSite=Lax and SameSite=None set paths — browsers use
+ * (name, domain, path) for cookie replacement, not SameSite, so
+ * either variant deletes the original regardless of its original
+ * SameSite attribute.
  */
-async function buildVerifierDeleteHeaders(authkit: Awaited<ReturnType<typeof getAuthkit>>): Promise<readonly string[]> {
+async function buildVerifierDeleteHeaders(
+  authkit: Awaited<ReturnType<typeof getAuthkit>> | undefined,
+  state: string | null,
+): Promise<readonly string[]> {
+  if (!state) return [];
+  if (!authkit) return deleteHeadersForState(state);
   try {
     const redirectUri = getRedirectUriFromContext();
-    const { response, headers } = await authkit.clearPendingVerifier(
-      new Response(),
-      redirectUri ? { redirectUri } : undefined,
-    );
+    const { response, headers } = await authkit.clearPendingVerifier(new Response(), {
+      state,
+      ...(redirectUri ? { redirectUri } : {}),
+    });
     const fromResponse = response?.headers.getSetCookie?.() ?? [];
     if (fromResponse.length > 0) return fromResponse;
     const fromBag = headers?.['Set-Cookie'];
     if (fromBag) return Array.isArray(fromBag) ? fromBag : [fromBag];
-    return STATIC_FALLBACK_DELETE_HEADERS;
+    return deleteHeadersForState(state);
   } catch (error) {
     console.error('[authkit-tanstack-react-start] clearPendingVerifier failed:', error);
-    return STATIC_FALLBACK_DELETE_HEADERS;
+    return deleteHeadersForState(state);
   }
 }
 
@@ -102,10 +114,10 @@ async function handleCallbackInternal(request: Request, options: HandleCallbackO
   const state = url.searchParams.get('state');
 
   if (!code) {
-    return errorResponse(new Error('Missing authorization code'), request, options, authkit, 400);
+    return errorResponse(new Error('Missing authorization code'), request, options, authkit, state, 400);
   }
   if (!authkit) {
-    return errorResponse(new Error('AuthKit not initialized'), request, options, authkit, 500);
+    return errorResponse(new Error('AuthKit not initialized'), request, options, authkit, state, 500);
   }
 
   try {
@@ -137,7 +149,7 @@ async function handleCallbackInternal(request: Request, options: HandleCallbackO
     return new Response(null, { status: 307, headers });
   } catch (error) {
     console.error('OAuth callback failed:', error);
-    return errorResponse(error, request, options, authkit, 500);
+    return errorResponse(error, request, options, authkit, state, 500);
   }
 }
 
@@ -146,11 +158,12 @@ async function errorResponse(
   request: Request,
   options: HandleCallbackOptions,
   authkit: Awaited<ReturnType<typeof getAuthkit>> | undefined,
+  state: string | null,
   defaultStatus: number,
 ): Promise<Response> {
   // Only the error path needs delete-cookie headers, so skip the
   // clearPendingVerifier round-trip on the happy path.
-  const deleteCookieHeaders = authkit ? await buildVerifierDeleteHeaders(authkit) : STATIC_FALLBACK_DELETE_HEADERS;
+  const deleteCookieHeaders = await buildVerifierDeleteHeaders(authkit, state);
 
   if (options.onError) {
     const userResponse = await options.onError({ error, request });

--- a/src/server/storage.spec.ts
+++ b/src/server/storage.spec.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getPKCECookieNameForState } from '@workos/authkit-session';
+
+const SEALED_STATE_FIXTURE = 'sealed-state-storage-spec';
+const PKCE_COOKIE_NAME = getPKCECookieNameForState(SEALED_STATE_FIXTURE);
 
 // Mock context before importing storage
 const mockSetPendingHeader = vi.fn();
@@ -39,17 +43,17 @@ describe('TanStackStartCookieSessionStorage', () => {
   describe('getCookie', () => {
     it('returns the named cookie value', async () => {
       const request = new Request('http://example.com', {
-        headers: { cookie: 'wos-auth-verifier=sealed-abc' },
+        headers: { cookie: `${PKCE_COOKIE_NAME}=sealed-abc` },
       });
 
-      const result = await storage.getCookie(request, 'wos-auth-verifier');
+      const result = await storage.getCookie(request, PKCE_COOKIE_NAME);
       expect(result).toBe('sealed-abc');
     });
 
     it('returns null without cookies', async () => {
       const request = new Request('http://example.com');
 
-      const result = await storage.getCookie(request, 'wos-auth-verifier');
+      const result = await storage.getCookie(request, PKCE_COOKIE_NAME);
       expect(result).toBeNull();
     });
 
@@ -58,44 +62,44 @@ describe('TanStackStartCookieSessionStorage', () => {
         headers: { cookie: 'other=value' },
       });
 
-      const result = await storage.getCookie(request, 'wos-auth-verifier');
+      const result = await storage.getCookie(request, PKCE_COOKIE_NAME);
       expect(result).toBeNull();
     });
 
     it('URI-decodes the cookie value', async () => {
       const encoded = encodeURIComponent('value with spaces & symbols');
       const request = new Request('http://example.com', {
-        headers: { cookie: `wos-auth-verifier=${encoded}` },
+        headers: { cookie: `${PKCE_COOKIE_NAME}=${encoded}` },
       });
 
-      const result = await storage.getCookie(request, 'wos-auth-verifier');
+      const result = await storage.getCookie(request, PKCE_COOKIE_NAME);
       expect(result).toBe('value with spaces & symbols');
     });
 
     it('returns the named cookie when mixed with others', async () => {
       const request = new Request('http://example.com', {
-        headers: { cookie: 'other=x; wos-auth-verifier=target; another=y' },
+        headers: { cookie: `other=x; ${PKCE_COOKIE_NAME}=target; another=y` },
       });
 
-      const result = await storage.getCookie(request, 'wos-auth-verifier');
+      const result = await storage.getCookie(request, PKCE_COOKIE_NAME);
       expect(result).toBe('target');
     });
 
     it('preserves = padding inside a sealed cookie value', async () => {
       const request = new Request('http://example.com', {
-        headers: { cookie: 'wos-auth-verifier=abc==' },
+        headers: { cookie: `${PKCE_COOKIE_NAME}=abc==` },
       });
 
-      const result = await storage.getCookie(request, 'wos-auth-verifier');
+      const result = await storage.getCookie(request, PKCE_COOKIE_NAME);
       expect(result).toBe('abc==');
     });
 
     it('returns null on malformed percent-encoding instead of throwing', async () => {
       const request = new Request('http://example.com', {
-        headers: { cookie: 'wos-auth-verifier=%E0%A4%A' },
+        headers: { cookie: `${PKCE_COOKIE_NAME}=%E0%A4%A` },
       });
 
-      const result = await storage.getCookie(request, 'wos-auth-verifier');
+      const result = await storage.getCookie(request, PKCE_COOKIE_NAME);
       expect(result).toBeNull();
     });
   });


### PR DESCRIPTION
## Summary

- Bump `@workos/authkit-session` to `^0.5.1`, which introduces per-flow PKCE verifier cookies named `wos-auth-verifier-<fnv1a8-of-state>`. Multi-tab sign-ins no longer clobber each other. 0.5.1 adds CWE-601 open-redirect protection on `returnPathname`.
- State-derive the error-path delete-cookie headers so they name the actual per-flow cookie instead of the removed static name. Skip emission when `state` is absent — the 10-minute TTL handles orphan cookies, and a fixed-name fallback can't match per-flow cookies anyway.
- Thread `state` through `clearPendingVerifier`, whose options now require it in 0.5.0.
- Update test fixtures to derive expected cookie names from the same `getPKCECookieNameForState` helper — tests no longer hard-code the wire name.
- Add `MIGRATION.md` covering the rollout caveat (in-flight flows spanning the upgrade fail once and retry) and the now-load-bearing Sign-in endpoint configuration in the WorkOS dashboard.
- Enable release-please `bump-minor-pre-major: true` so the accompanying `BREAKING CHANGE:` footer produces **0.6.0 → 0.7.0** (minor bump pre-1.0) rather than release-please's default major-bump-to-1.0.0.

## Breaking change

Per MIGRATION.md: each OAuth flow now requires a per-flow verifier cookie set at sign-in time, bound to the URL \`state\`. Integrators must configure the **Sign-in endpoint** (\`initiate_login_uri\`) in the WorkOS dashboard or dashboard impersonation, IdP-initiated SSO, session-expiry reauth, and \`prompt=login\` flows will fail with \`PKCECookieMissingError\`.

## Test plan

- [ ] \`pnpm build\` passes (includes typecheck)
- [ ] \`pnpm test\` passes
- [ ] \`cd example && pnpm build\` passes with no \`node:crypto\` / Node-only externalization warnings in the client chunk
- [ ] Sign-in from the example app succeeds end-to-end against a dev WorkOS project
- [ ] Callback error paths emit state-derived \`Set-Cookie\` delete headers
- [ ] MIGRATION.md renders correctly on GitHub
- [ ] After merge, release-please PR (currently #67 at \`0.6.1\`) re-bakes to \`0.7.0\`