### PR TITLE
feat(pkce)!: retroactively classify #68 for release-please (targets 0.7.0)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,7 @@
 # Migration Guide
 
+See [CHANGELOG.md](./CHANGELOG.md) for the full per-release summary.
+
 ## 0.6.0 → 0.7.0
 
 First release with PKCE state binding via `@workos/authkit-session@0.5.1`. The


### PR DESCRIPTION
## Why this PR exists (take 2)

#70 tried to solve the same problem with an empty commit, but squash-merge of an empty diff produces **no commit on main** — GitHub marks the PR as merged (same sha as the pre-merge HEAD) and release-please never sees a new commit to classify.

This PR reproduces the same conventional-commit message with a **tiny real diff** (one-line \`MIGRATION.md\` cross-reference) so squash-merge actually lands a new commit. That commit's subject is \`feat(pkce)!:\` with a \`BREAKING CHANGE:\` footer, which — combined with the \`bump-minor-pre-major: true\` config — drives release-please to \`0.7.0\`.

## Why PR #68 needed this fix at all

#68's squash-merge commit was titled \`Adopt per-flow PKCE cookies (authkit-session 0.5.1) (#68)\` with no conventional-commit prefix. Release-please silently skipped it, leaving PR #67 (\`chore(main): release 0.6.1\`) unchanged — bumping only for unrelated \`fix:\` commits on main, not the PKCE migration.

## Expected behavior after merge

Release-please PR #67 will re-bake to:

- **Title** → \`chore(main): release 0.7.0\`
- **Version** → \`0.6.0 → 0.7.0\` (breaking under \`bump-minor-pre-major\`)
- **CHANGELOG.md** → populated with the per-flow PKCE migration notes

## Merge method

Safe under either strategy this time — the diff is non-empty so squash-merge will produce a commit. But:

- **Squash-merge**: GitHub will use this PR's title (\`feat(pkce)!:...\`) as the commit subject. ✓
- **Merge-commit / rebase**: preserves the internal commit message verbatim. ✓

Both work. Pick whichever matches repo convention.