### PR TITLE
feat(callback): centralize logging and add errorRedirectUrl option

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,26 +411,38 @@ export const Route = createFileRoute('/api/auth/callback')({
 });
 ```
 
-**With hooks for custom logic:**
+**With a sign-in error page (browser-friendly default):**
 
 ```typescript
 export const Route = createFileRoute('/api/auth/callback')({
   server: {
     handlers: {
       GET: handleCallbackRoute({
+        errorRedirectUrl: '/sign-in?error=auth_failed',
+      }),
+    },
+  },
+});
+```
+
+The user lands on `/sign-in?error=auth_failed` (a route you own) instead of seeing raw JSON. Verifier-delete cookies are still attached.
+
+**With Sentry capture:**
+
+```typescript
+import * as Sentry from '@sentry/node';
+
+export const Route = createFileRoute('/api/auth/callback')({
+  server: {
+    handlers: {
+      GET: handleCallbackRoute({
         onSuccess: async ({ user, authenticationMethod }) => {
-          // Create user record in your database
           await db.users.upsert({ id: user.id, email: user.email });
-          // Track analytics
           analytics.track('User Signed In', { method: authenticationMethod });
         },
         onError: ({ error, request }) => {
-          // Custom error handling
-          console.error('Auth failed:', error);
-          return new Response(JSON.stringify({ error: 'Authentication failed' }), {
-            status: 500,
-            headers: { 'Content-Type': 'application/json' },
-          });
+          Sentry.captureException(error, { extra: { url: request.url } });
+          return Response.redirect(new URL('/sign-in?error=auth_failed', request.url));
         },
       }),
     },
@@ -438,11 +450,14 @@ export const Route = createFileRoute('/api/auth/callback')({
 });
 ```
 
+`onError` runs for every callback failure (missing `code`, state mismatch, token exchange failure, `onSuccess` throws). The SDK already emits a `console.error` for every failure, so if you wire Sentry's `console.error` ingestion you don't need to call `Sentry.captureException` yourself.
+
 **Options:**
 
-- `onSuccess?: (data) => Promise<void>` - Called after successful authentication with user data, tokens, and authentication method
-- `onError?: ({ error, request }) => Response` - Custom error handler that returns a Response
-- `returnPathname?: string` - Override the redirect path after authentication (defaults to state or `/`)
+- `onSuccess?: (data) => Promise<void>` — Called after successful authentication with user data, tokens, and authentication method.
+- `onError?: ({ error, request }) => Response` — Custom error handler that returns a Response. Errors thrown from inside `onError` are NOT caught by the SDK.
+- `errorRedirectUrl?: string` — URL (absolute or relative) to redirect to on callback failure when `onError` is not set. If both are set, `onError` wins. Set this at route-construction time only — do not derive from request input (it would be an open-redirect vector).
+- `returnPathname?: string` — Override the success-path redirect after authentication. Does not apply to errors.
 
 ### Client Hooks
 

--- a/src/server/server.spec.ts
+++ b/src/server/server.spec.ts
@@ -337,6 +337,22 @@ describe('handleCallbackRoute', () => {
       expect(setCookies.every((c) => c.includes('Max-Age=0'))).toBe(true);
     });
 
+    it('logs the original setup error when getAuthkit() rejects', async () => {
+      const originalError = new Error('Config missing');
+      mockGetAuthkitImpl = () => Promise.reject(originalError);
+      const request = new Request(
+        `http://example.com/callback?code=auth_123&state=${encodeURIComponent(SEALED_STATE)}`,
+      );
+
+      await handleCallbackRoute()({ request });
+
+      const callbackErrorLogs = consoleErrorSpy.mock.calls.filter(
+        (args) => typeof args[0] === 'string' && args[0].includes('OAuth callback failed'),
+      );
+      expect(callbackErrorLogs).toHaveLength(1);
+      expect(callbackErrorLogs[0]![1]).toBe(originalError);
+    });
+
     it.each<{ label: string; arrange: () => Request; options?: HandleCallbackOptions }>([
       {
         label: 'missing code',
@@ -478,6 +494,12 @@ describe('handleCallbackRoute', () => {
 
       expect(response.status).toBe(400);
       expect(response.headers.get('Content-Type')).toBe('application/json');
+
+      const malformedLogs = consoleErrorSpy.mock.calls.filter(
+        (args) => typeof args[0] === 'string' && args[0].includes('errorRedirectUrl is malformed'),
+      );
+      expect(malformedLogs).toHaveLength(1);
+      expect(malformedLogs[0]![0]).toContain('falling back to JSON 400');
     });
 
     it('ignores returnPathname on the error path', async () => {

--- a/src/server/server.spec.ts
+++ b/src/server/server.spec.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getPKCECookieNameForState } from '@workos/authkit-session';
+import type { HandleCallbackOptions } from './types';
 
 const SEALED_STATE = 'sealed-state-fixture';
 const PKCE_COOKIE_NAME = getPKCECookieNameForState(SEALED_STATE);
@@ -56,6 +57,8 @@ const successResult = (overrides: Record<string, unknown> = {}) => ({
 });
 
 describe('handleCallbackRoute', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockRedirectUriFromContext = undefined;
@@ -66,6 +69,11 @@ describe('handleCallbackRoute', () => {
         createSignIn: mockCreateSignIn,
         clearPendingVerifier: mockClearPendingVerifier,
       });
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
   });
 
   describe('missing code', () => {
@@ -240,7 +248,6 @@ describe('handleCallbackRoute', () => {
     it('returns 500 with generic body on handleCallback failure', async () => {
       const request = new Request(`http://example.com/callback?code=invalid&state=${encodeURIComponent(SEALED_STATE)}`);
       mockHandleCallback.mockRejectedValue(new Error('Invalid code'));
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
       const response = await handleCallbackRoute()({ request });
 
@@ -250,8 +257,6 @@ describe('handleCallbackRoute', () => {
       expect(body.error.description).toContain("Couldn't sign in");
       expect(body.error).not.toHaveProperty('details');
       expect(response.headers.getSetCookie().some((c) => c.startsWith(`${PKCE_COOKIE_NAME}=`))).toBe(true);
-
-      consoleSpy.mockRestore();
     });
 
     it('calls onError with the underlying error and appends delete-cookie', async () => {
@@ -264,7 +269,6 @@ describe('handleCallbackRoute', () => {
           headers: { 'X-Custom': 'preserved' },
         }),
       );
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
       const response = await handleCallbackRoute({ onError })({ request });
 
@@ -273,8 +277,6 @@ describe('handleCallbackRoute', () => {
       expect(response.headers.get('X-Custom')).toBe('preserved');
       expect(await response.text()).toBe('Custom error page');
       expect(response.headers.getSetCookie().some((c) => c.startsWith(`${PKCE_COOKIE_NAME}=`))).toBe(true);
-
-      consoleSpy.mockRestore();
     });
 
     it('reads verifier-delete header from clearPendingVerifier response when headers bag is empty', async () => {
@@ -322,7 +324,6 @@ describe('handleCallbackRoute', () => {
         `http://example.com/callback?code=auth_123&state=${encodeURIComponent(SEALED_STATE)}`,
       );
       mockGetAuthkitImpl = () => Promise.reject(new Error('Config missing'));
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
       const response = await handleCallbackRoute()({ request });
 
@@ -334,8 +335,173 @@ describe('handleCallbackRoute', () => {
       expect(setCookies[1]).toContain('SameSite=None');
       expect(setCookies[1]).toContain('Secure');
       expect(setCookies.every((c) => c.includes('Max-Age=0'))).toBe(true);
+    });
 
-      consoleSpy.mockRestore();
+    it.each<{ label: string; arrange: () => Request; options?: HandleCallbackOptions }>([
+      {
+        label: 'missing code',
+        arrange: () => new Request(`http://example.com/callback?state=${encodeURIComponent(SEALED_STATE)}`),
+      },
+      {
+        label: 'getAuthkit throws',
+        arrange: () => {
+          mockGetAuthkitImpl = () => Promise.reject(new Error('Config missing'));
+          return new Request(`http://example.com/callback?code=auth_123&state=${encodeURIComponent(SEALED_STATE)}`);
+        },
+      },
+      {
+        label: 'handleCallback throws',
+        arrange: () => {
+          mockHandleCallback.mockRejectedValue(new Error('Token exchange failure'));
+          return new Request(`http://example.com/callback?code=auth_123&state=${encodeURIComponent(SEALED_STATE)}`);
+        },
+      },
+      {
+        label: 'onSuccess throws',
+        arrange: () => {
+          mockHandleCallback.mockResolvedValue(successResult());
+          return new Request(`http://example.com/callback?code=auth_123&state=${encodeURIComponent(SEALED_STATE)}`);
+        },
+        options: {
+          onSuccess: () => {
+            throw new Error('db failure');
+          },
+        },
+      },
+    ])('central console.error fires exactly once on $label', async ({ arrange, options }) => {
+      const request = arrange();
+      await handleCallbackRoute(options ?? {})({ request });
+
+      const callbackErrorLogs = consoleErrorSpy.mock.calls.filter(
+        (args) => typeof args[0] === 'string' && args[0].includes('OAuth callback failed'),
+      );
+      expect(callbackErrorLogs).toHaveLength(1);
+    });
+
+    it('routes onSuccess throws through errorResponse with delete-cookies', async () => {
+      const request = new Request(
+        `http://example.com/callback?code=auth_123&state=${encodeURIComponent(SEALED_STATE)}`,
+      );
+      mockHandleCallback.mockResolvedValue(successResult());
+      const onSuccess = vi.fn(() => {
+        throw new Error('db failure');
+      });
+
+      const response = await handleCallbackRoute({ onSuccess })({ request });
+
+      expect(response.status).toBe(500);
+      expect(response.headers.getSetCookie().some((c) => c.startsWith(`${PKCE_COOKIE_NAME}=`))).toBe(true);
+    });
+
+    it('does not catch errors thrown inside onError', async () => {
+      const request = new Request(
+        `http://example.com/callback?code=auth_123&state=${encodeURIComponent(SEALED_STATE)}`,
+      );
+      mockHandleCallback.mockRejectedValue(new Error('callback failure'));
+      const onError = vi.fn(() => {
+        throw new Error('user-side failure');
+      });
+
+      await expect(
+        handleCallbackRoute({ onError, errorRedirectUrl: '/fallback' })({ request }),
+      ).rejects.toThrow('user-side failure');
+    });
+  });
+
+  describe('errorRedirectUrl path', () => {
+    it('returns 302 to absolute errorRedirectUrl with delete-cookies', async () => {
+      const request = new Request(
+        `http://example.com/callback?code=invalid&state=${encodeURIComponent(SEALED_STATE)}`,
+      );
+      mockHandleCallback.mockRejectedValue(new Error('boom'));
+
+      const response = await handleCallbackRoute({ errorRedirectUrl: 'https://example.com/sign-in?error=auth' })({
+        request,
+      });
+
+      expect(response.status).toBe(302);
+      expect(response.headers.get('Location')).toBe('https://example.com/sign-in?error=auth');
+      expect(response.headers.getSetCookie().some((c) => c.startsWith(`${PKCE_COOKIE_NAME}=`))).toBe(true);
+    });
+
+    it('resolves relative errorRedirectUrl against request origin', async () => {
+      const request = new Request(
+        `http://example.com/callback?code=invalid&state=${encodeURIComponent(SEALED_STATE)}`,
+      );
+      mockHandleCallback.mockRejectedValue(new Error('boom'));
+
+      const response = await handleCallbackRoute({ errorRedirectUrl: '/sign-in?error=auth_failed' })({ request });
+
+      expect(response.status).toBe(302);
+      expect(response.headers.get('Location')).toBe('http://example.com/sign-in?error=auth_failed');
+    });
+
+    it('runs onError and ignores errorRedirectUrl when both are set', async () => {
+      const request = new Request(
+        `http://example.com/callback?code=invalid&state=${encodeURIComponent(SEALED_STATE)}`,
+      );
+      mockHandleCallback.mockRejectedValue(new Error('boom'));
+      const onError = vi.fn(() => new Response('custom', { status: 418 }));
+
+      const response = await handleCallbackRoute({ onError, errorRedirectUrl: '/should-not-be-used' })({ request });
+
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(response.status).toBe(418);
+      expect(response.headers.get('Location')).toBeNull();
+
+      const callbackErrorLogs = consoleErrorSpy.mock.calls.filter(
+        (args) => typeof args[0] === 'string' && args[0].includes('OAuth callback failed'),
+      );
+      expect(callbackErrorLogs).toHaveLength(1);
+    });
+
+    it('falls back to JSON when errorRedirectUrl is malformed', async () => {
+      const request = new Request(
+        `http://example.com/callback?code=invalid&state=${encodeURIComponent(SEALED_STATE)}`,
+      );
+      mockHandleCallback.mockRejectedValue(new Error('boom'));
+
+      const response = await handleCallbackRoute({ errorRedirectUrl: 'http://[::1' })({ request });
+
+      expect(response.status).toBe(500);
+      expect(response.headers.get('Content-Type')).toBe('application/json');
+      const body = await response.json();
+      expect(body.error.message).toBe('Authentication failed');
+      expect(response.headers.getSetCookie().some((c) => c.startsWith(`${PKCE_COOKIE_NAME}=`))).toBe(true);
+
+      const callbackLogs = consoleErrorSpy.mock.calls.filter(
+        (args) => typeof args[0] === 'string' && args[0].includes('OAuth callback failed'),
+      );
+      const malformedLogs = consoleErrorSpy.mock.calls.filter(
+        (args) => typeof args[0] === 'string' && args[0].includes('errorRedirectUrl is malformed'),
+      );
+      expect(callbackLogs).toHaveLength(1);
+      expect(malformedLogs).toHaveLength(1);
+    });
+
+    it('falls back to JSON 400 when errorRedirectUrl is malformed on missing-code path', async () => {
+      const request = new Request(`http://example.com/callback?state=${encodeURIComponent(SEALED_STATE)}`);
+
+      const response = await handleCallbackRoute({ errorRedirectUrl: 'http://[::1' })({ request });
+
+      expect(response.status).toBe(400);
+      expect(response.headers.get('Content-Type')).toBe('application/json');
+    });
+
+    it('ignores returnPathname on the error path', async () => {
+      const request = new Request(
+        `http://example.com/callback?code=invalid&state=${encodeURIComponent(SEALED_STATE)}`,
+      );
+      mockHandleCallback.mockRejectedValue(new Error('boom'));
+
+      const response = await handleCallbackRoute({
+        returnPathname: '/dashboard',
+        errorRedirectUrl: '/sign-in?error=auth',
+      })({ request });
+
+      expect(response.status).toBe(302);
+      expect(response.headers.get('Location')).toContain('/sign-in?error=auth');
+      expect(response.headers.get('Location')).not.toContain('/dashboard');
     });
   });
 
@@ -346,13 +512,10 @@ describe('handleCallbackRoute', () => {
       // Force the error path so errorResponse runs. `code=bad` with the mock
       // rejecting triggers the catch branch.
       mockHandleCallback.mockRejectedValue(new Error('boom'));
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
       const res = await handleCallbackRoute()({ request });
       const setCookies = res.headers.getSetCookie();
       expect(setCookies.some((c) => c.startsWith(`${expected}=`))).toBe(true);
-
-      consoleSpy.mockRestore();
     });
 
     it('emits no Set-Cookie delete when state is absent', async () => {

--- a/src/server/server.spec.ts
+++ b/src/server/server.spec.ts
@@ -402,17 +402,15 @@ describe('handleCallbackRoute', () => {
         throw new Error('user-side failure');
       });
 
-      await expect(
-        handleCallbackRoute({ onError, errorRedirectUrl: '/fallback' })({ request }),
-      ).rejects.toThrow('user-side failure');
+      await expect(handleCallbackRoute({ onError, errorRedirectUrl: '/fallback' })({ request })).rejects.toThrow(
+        'user-side failure',
+      );
     });
   });
 
   describe('errorRedirectUrl path', () => {
     it('returns 302 to absolute errorRedirectUrl with delete-cookies', async () => {
-      const request = new Request(
-        `http://example.com/callback?code=invalid&state=${encodeURIComponent(SEALED_STATE)}`,
-      );
+      const request = new Request(`http://example.com/callback?code=invalid&state=${encodeURIComponent(SEALED_STATE)}`);
       mockHandleCallback.mockRejectedValue(new Error('boom'));
 
       const response = await handleCallbackRoute({ errorRedirectUrl: 'https://example.com/sign-in?error=auth' })({
@@ -425,9 +423,7 @@ describe('handleCallbackRoute', () => {
     });
 
     it('resolves relative errorRedirectUrl against request origin', async () => {
-      const request = new Request(
-        `http://example.com/callback?code=invalid&state=${encodeURIComponent(SEALED_STATE)}`,
-      );
+      const request = new Request(`http://example.com/callback?code=invalid&state=${encodeURIComponent(SEALED_STATE)}`);
       mockHandleCallback.mockRejectedValue(new Error('boom'));
 
       const response = await handleCallbackRoute({ errorRedirectUrl: '/sign-in?error=auth_failed' })({ request });
@@ -437,9 +433,7 @@ describe('handleCallbackRoute', () => {
     });
 
     it('runs onError and ignores errorRedirectUrl when both are set', async () => {
-      const request = new Request(
-        `http://example.com/callback?code=invalid&state=${encodeURIComponent(SEALED_STATE)}`,
-      );
+      const request = new Request(`http://example.com/callback?code=invalid&state=${encodeURIComponent(SEALED_STATE)}`);
       mockHandleCallback.mockRejectedValue(new Error('boom'));
       const onError = vi.fn(() => new Response('custom', { status: 418 }));
 
@@ -456,9 +450,7 @@ describe('handleCallbackRoute', () => {
     });
 
     it('falls back to JSON when errorRedirectUrl is malformed', async () => {
-      const request = new Request(
-        `http://example.com/callback?code=invalid&state=${encodeURIComponent(SEALED_STATE)}`,
-      );
+      const request = new Request(`http://example.com/callback?code=invalid&state=${encodeURIComponent(SEALED_STATE)}`);
       mockHandleCallback.mockRejectedValue(new Error('boom'));
 
       const response = await handleCallbackRoute({ errorRedirectUrl: 'http://[::1' })({ request });
@@ -489,9 +481,7 @@ describe('handleCallbackRoute', () => {
     });
 
     it('ignores returnPathname on the error path', async () => {
-      const request = new Request(
-        `http://example.com/callback?code=invalid&state=${encodeURIComponent(SEALED_STATE)}`,
-      );
+      const request = new Request(`http://example.com/callback?code=invalid&state=${encodeURIComponent(SEALED_STATE)}`);
       mockHandleCallback.mockRejectedValue(new Error('boom'));
 
       const response = await handleCallbackRoute({

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -103,10 +103,11 @@ async function buildVerifierDeleteHeaders(
 async function handleCallbackInternal(request: Request, options: HandleCallbackOptions): Promise<Response> {
   let authkit: Awaited<ReturnType<typeof getAuthkit>> | undefined;
 
+  let setupError: unknown;
   try {
     authkit = await getAuthkit();
-  } catch {
-    // Swallowed: errorResponse below logs centrally when authkit is missing.
+  } catch (error) {
+    setupError = error;
   }
 
   const url = new URL(request.url);
@@ -117,7 +118,7 @@ async function handleCallbackInternal(request: Request, options: HandleCallbackO
     return errorResponse(new Error('Missing authorization code'), request, options, authkit, state, 400);
   }
   if (!authkit) {
-    return errorResponse(new Error('AuthKit not initialized'), request, options, authkit, state, 500);
+    return errorResponse(setupError ?? new Error('AuthKit not initialized'), request, options, authkit, state, 500);
   }
 
   try {
@@ -185,7 +186,7 @@ async function errorResponse(
       return new Response(null, { status: 302, headers });
     } catch (urlError) {
       console.error(
-        '[authkit-tanstack-react-start] errorRedirectUrl is malformed; falling back to JSON 500:',
+        `[authkit-tanstack-react-start] errorRedirectUrl is malformed; falling back to JSON ${defaultStatus}:`,
         urlError,
       );
       // fall through to JSON

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -105,8 +105,8 @@ async function handleCallbackInternal(request: Request, options: HandleCallbackO
 
   try {
     authkit = await getAuthkit();
-  } catch (setupError) {
-    console.error('[authkit-tanstack-react-start] Callback setup failed:', setupError);
+  } catch {
+    // Swallowed: errorResponse below logs centrally when authkit is missing.
   }
 
   const url = new URL(request.url);
@@ -148,7 +148,6 @@ async function handleCallbackInternal(request: Request, options: HandleCallbackO
 
     return new Response(null, { status: 307, headers });
   } catch (error) {
-    console.error('OAuth callback failed:', error);
     return errorResponse(error, request, options, authkit, state, 500);
   }
 }
@@ -161,6 +160,8 @@ async function errorResponse(
   state: string | null,
   defaultStatus: number,
 ): Promise<Response> {
+  console.error('[authkit-tanstack-react-start] OAuth callback failed:', error);
+
   // Only the error path needs delete-cookie headers, so skip the
   // clearPendingVerifier round-trip on the happy path.
   const deleteCookieHeaders = await buildVerifierDeleteHeaders(authkit, state);
@@ -174,6 +175,21 @@ async function errorResponse(
       statusText: userResponse.statusText,
       headers,
     });
+  }
+
+  if (options.errorRedirectUrl) {
+    try {
+      const target = new URL(options.errorRedirectUrl, request.url);
+      const headers = new Headers({ Location: target.toString() });
+      for (const h of deleteCookieHeaders) headers.append('Set-Cookie', h);
+      return new Response(null, { status: 302, headers });
+    } catch (urlError) {
+      console.error(
+        '[authkit-tanstack-react-start] errorRedirectUrl is malformed; falling back to JSON 500:',
+        urlError,
+      );
+      // fall through to JSON
+    }
   }
 
   const headers = new Headers({ 'Content-Type': 'application/json' });

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -11,7 +11,37 @@ export interface OauthTokens {
 export interface HandleCallbackOptions {
   returnPathname?: string;
   onSuccess?: (data: HandleAuthSuccessData) => void | Promise<void>;
+  /**
+   * Custom error handler. Receives the underlying error and the original
+   * request, returns a Response. Errors thrown from inside `onError` are
+   * NOT caught by the SDK — they propagate up to the runtime. Wrap your
+   * `onError` body in a try/catch if you want different behavior.
+   *
+   * If both `onError` and `errorRedirectUrl` are provided, `onError` wins
+   * and `errorRedirectUrl` is ignored.
+   */
   onError?: (params: { error?: unknown; request: Request }) => Response | Promise<Response>;
+  /**
+   * Optional URL to redirect the user to when the callback fails. Accepts
+   * absolute URLs (`https://example.com/sign-in`) or relative paths
+   * (`/sign-in?error=auth_failed`); relative values resolve against the
+   * request origin.
+   *
+   * When set and `onError` is not, the SDK responds with a 302 Location
+   * redirect plus the verifier-delete cookies. When `onError` is also
+   * set, this option is ignored.
+   *
+   * The redirect URL is set at route-construction time by application
+   * code, not derived from request input. Do not pass user-controlled
+   * values here. The SDK does not validate the URL scheme; any value the
+   * URL constructor accepts is accepted (including `javascript:` and
+   * `data:`).
+   *
+   * If the value is malformed and the URL constructor throws, the SDK
+   * logs a config warning and falls back to the path-dependent JSON
+   * error response (400 or 500) with delete-cookies.
+   */
+  errorRedirectUrl?: string;
 }
 
 export interface HandleAuthSuccessData {


### PR DESCRIPTION
## Summary

- **Centralizes callback error logging.** Every error path through `handleCallbackRoute` now emits exactly one `[authkit-tanstack-react-start] OAuth callback failed:` line via a single log point at the top of `errorResponse`. Removes the two scattered `console.error` calls at the previous setup-failure and handle-callback-failure sites. The missing-`code` and `onSuccess`-throws paths now also log uniformly. `buildVerifierDeleteHeaders`'s own auxiliary log is left untouched (different concern).
- **Adds opt-in browser-friendly redirect via `errorRedirectUrl`.** New string option on `HandleCallbackOptions`. When set (and `onError` is not), `errorResponse` returns a 302 with `Location` set to the resolved URL plus the verifier-delete cookies. Accepts absolute URLs and relative paths (resolved against `request.url`). Malformed values fall back to the existing path-dependent JSON response (400 or 500) with a separate config-warning log line.
- **Preserves existing semantics.** `onError` still wins precedence when both are set. Errors thrown inside `onError` are explicitly NOT caught by the SDK — locked in by a regression test against the new `errorRedirectUrl` try/catch broadening. JSON-fallback shape, status codes, and delete-cookie headers unchanged when neither option is set.

The customer incident this addresses: a stale verifier cookie or PKCE state mismatch caused the SDK to surface raw JSON to the user's browser. Callers who set `errorRedirectUrl` now bounce users to a route they own (e.g., `/sign-in?error=auth_failed`) with verifier-delete cookies still attached. Callers who want observability can wire Sentry inside `onError` (or rely on the central `console.error` ingestion) and get a uniform signal.

## What's in the diff

| File | Change |
| --- | --- |
| `src/server/types.ts` | Adds `errorRedirectUrl?: string` field with JSDoc covering relative/absolute resolution, precedence vs `onError`, malformed-value fallback, and open-redirect warning. Adds throw-not-caught note to `onError` JSDoc. |
| `src/server/server.ts` | Removes `console.error` at the prior setup-failure and handle-callback-failure call sites. Adds central `console.error` at the top of `errorResponse`. Adds `errorRedirectUrl` branch between the `onError` short-circuit and JSON fallback, with a tightly scoped try/catch around `new URL()` that logs a config warning and falls through to JSON on malformed input. |
| `src/server/server.spec.ts` | Promotes `console.error` spy to top-level `beforeEach`/`afterEach`. Adds 12 new test cases (4 from `it.each` for log-fires-once across all error paths, plus explicit cases for absolute/relative `errorRedirectUrl`, precedence, malformed-URL fallback on both 400 and 500 paths, `onSuccess`-throws routing, `returnPathname`-ignored-on-error, and a regression test that `onError` throws are not caught). |
| `README.md` | Replaces `handleCallbackRoute` section with three examples (basic, sign-in error page, Sentry capture), updates the Options list with the new field, and adds the precedence + open-redirect notes. |

## Backward compatibility

Non-breaking. With neither `onError` nor `errorRedirectUrl` set, the response is semantically identical to today: `400` for missing `code`, `500` for setup/handleCallback/onSuccess failures, `Content-Type: application/json`, same JSON body shape, same delete-cookie headers. Existing tests (and the example app's existing `onError`-using callback) continue to pass.

## Test plan

- [x] `pnpm test src/server/server.spec.ts` — 32/32 (was 20/20 before).
- [x] `pnpm test` — full suite, 215/215.
- [x] `pnpm build` — typecheck + library build.
- [x] `cd example && pnpm build` — no Node-only externalization warnings in the client chunk.
- [x] Manual end-to-end in the example app:
  - [x] Default (no options): missing-`code` shows JSON 400, exactly one `OAuth callback failed:` log line.
  - [x] `errorRedirectUrl` only: 302 Location + verifier cookies cleared.
  - [x] `onError` + `errorRedirectUrl`: `onError` wins, both logs fire (central + user's), no redirect.
  - [x] Malformed `errorRedirectUrl` (`http://[::1`): falls back to JSON, both logs fire in order (central first, malformed second).
  - [x] Production reproducer (stale verifier cookie + real OAuth flow with `errorRedirectUrl: '/sign-in?error=auth_failed'`): browser lands on `/sign-in?error=auth_failed` instead of raw JSON.

## Out of scope

Per the contract:
- Re-throw-by-default behavior — would be breaking; defer until coordinated with `authkit-nextjs`.
- Sentry SDK as a dependency — caller wires it inside their own `onError`.
- URL-scheme allowlist for `errorRedirectUrl` — developer-controlled value; documented as such.
- Aligning `authkit-nextjs` to match — separate repo, separate release.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/workos/authkit-tanstack-start/pull/74" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
