### PR TITLE
fix: add @workos-inc/node as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@workos/authkit-session": "^0.5.1"
   },
   "peerDependencies": {
+    "@workos-inc/node": "^8.0.0 || ^9.0.0",
     "@tanstack/react-router": ">=1.0.0",
     "@tanstack/react-start": ">=1.0.0",
     "react": "^18.0 || ^19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@workos-inc/node':
+        specifier: ^8.0.0 || ^9.0.0
+        version: 8.13.0
       '@workos/authkit-session':
         specifier: ^0.5.1
         version: 0.5.1(typescript@5.9.3)


### PR DESCRIPTION
## Summary

- Adds `@workos-inc/node` with range `^8.0.0 || ^9.0.0` to `peerDependencies`

## Context

Companion to [workos/authkit-session#32](https://github.com/workos/authkit-session/pull/32).

This package re-exports types that originate from `@workos-inc/node` (e.g., `User`, `Impersonator` via `authkit-session`). Declaring the SDK as an explicit peer dependency makes the requirement visible at install time and ensures a single copy at runtime — preventing type mismatches for consumers on `@workos-inc/node@9.x`.

## Test plan

- [x] `pnpm run build` passes
- [x] `pnpm test` — 217/217 tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/workos/authkit-tanstack-start/pull/83" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->