### PR TITLE
fix: update to authkit-session@0.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "url": "https://github.com/workos/authkit-tanstack-start/issues"
   },
   "dependencies": {
-    "@workos/authkit-session": "^0.5.2"
+    "@workos/authkit-session": "^0.5.3"
   },
   "peerDependencies": {
     "@tanstack/react-router": ">=1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@workos/authkit-session':
-        specifier: ^0.5.2
-        version: 0.5.2(@workos-inc/node@8.13.0)(typescript@5.9.3)
+        specifier: ^0.5.3
+        version: 0.5.3(@workos-inc/node@8.13.0)(typescript@5.9.3)
     devDependencies:
       '@tanstack/react-router':
         specifier: ^1.154.8
@@ -2030,8 +2030,8 @@ packages:
     resolution: {integrity: sha512-NgQKHpwh8AbT4KvAsW91Y+4f4jja2IvFPQ5atcy5NUxUMVRgXzRFEee3erawfXrTmiCVqJjd9PljHySKBXmHKQ==}
     engines: {node: '>=20.15.0'}
 
-  '@workos/authkit-session@0.5.2':
-    resolution: {integrity: sha512-1Gf04z6IzxKkq+wLaSF85LMgguoXNz3wR6RwPxO431WkUl7eIXECI2ovhzBsaCSSIpSMJaDL6QtjKd+9PClO6g==}
+  '@workos/authkit-session@0.5.3':
+    resolution: {integrity: sha512-5CZhCcDHBj64kKb5ZVi/GFHEeLMMqK+UbqIFzGVDTbApWjzBKz21rnZxEOroc1oDvu1dUC4Q2tFoD7V+NeuJSw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@workos-inc/node': ^8.0.0 || ^9.0.0
@@ -4772,7 +4772,7 @@ snapshots:
     dependencies:
       eventemitter3: 5.0.4
 
-  '@workos/authkit-session@0.5.2(@workos-inc/node@8.13.0)(typescript@5.9.3)':
+  '@workos/authkit-session@0.5.3(@workos-inc/node@8.13.0)(typescript@5.9.3)':
     dependencies:
       '@workos-inc/node': 8.13.0
       iron-webcrypto: 2.0.0


### PR DESCRIPTION
This pull request updates the `@workos/authkit-session` dependency from version 0.5.2 to 0.5.3 across the project to ensure the latest fixes and improvements are included.

Dependency updates:

* Updated the `@workos/authkit-session` version from 0.5.2 to 0.5.3 in `package.json`.
* Updated the version and integrity hash for `@workos/authkit-session` to 0.5.3 in `pnpm-lock.yaml` under `importers`, `packages`, and `snapshots` sections. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12-R13) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2033-R2034) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4775-R4775)