### PR TITLE
fix: evict stale PKCE verifier cookies to prevent HTTP 431 (#76)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "url": "https://github.com/workos/authkit-tanstack-start/issues"
   },
   "dependencies": {
-    "@workos/authkit-session": "^0.5.3"
+    "@workos/authkit-session": "^0.6.0"
   },
   "peerDependencies": {
     "@tanstack/react-router": ">=1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@workos/authkit-session':
-        specifier: ^0.5.3
-        version: 0.5.3(@workos-inc/node@8.13.0)(typescript@5.9.3)
+        specifier: ^0.6.0
+        version: 0.6.0(@workos-inc/node@8.13.0)(typescript@5.9.3)
     devDependencies:
       '@tanstack/react-router':
         specifier: ^1.154.8
@@ -2030,11 +2030,11 @@ packages:
     resolution: {integrity: sha512-NgQKHpwh8AbT4KvAsW91Y+4f4jja2IvFPQ5atcy5NUxUMVRgXzRFEee3erawfXrTmiCVqJjd9PljHySKBXmHKQ==}
     engines: {node: '>=20.15.0'}
 
-  '@workos/authkit-session@0.5.3':
-    resolution: {integrity: sha512-5CZhCcDHBj64kKb5ZVi/GFHEeLMMqK+UbqIFzGVDTbApWjzBKz21rnZxEOroc1oDvu1dUC4Q2tFoD7V+NeuJSw==}
+  '@workos/authkit-session@0.6.0':
+    resolution: {integrity: sha512-AaDt34h4XF5BTF5ShN+W+8OOHxj+n0KmkX+e89OVNaeZJKwqao0b/S3m3BiAylNHdZGM95tsvRUKeoEXp5qERQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
-      '@workos-inc/node': ^8.0.0 || ^9.0.0
+      '@workos-inc/node': ^8.0.0 || ^9.0.0 || ^10.0.0
 
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
@@ -4772,7 +4772,7 @@ snapshots:
     dependencies:
       eventemitter3: 5.0.4
 
-  '@workos/authkit-session@0.5.3(@workos-inc/node@8.13.0)(typescript@5.9.3)':
+  '@workos/authkit-session@0.6.0(@workos-inc/node@8.13.0)(typescript@5.9.3)':
     dependencies:
       '@workos-inc/node': 8.13.0
       iron-webcrypto: 2.0.0

--- a/src/server/cookie-utils.spec.ts
+++ b/src/server/cookie-utils.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseCookies } from './cookie-utils';
+import { parseCookies, parseCookieNames } from './cookie-utils';
 
 describe('parseCookies', () => {
   it('parses a single cookie', () => {
@@ -21,5 +21,28 @@ describe('parseCookies', () => {
 
   it('trims whitespace around each pair', () => {
     expect(parseCookies('a=1 ;   b=2')).toEqual({ a: '1', b: '2' });
+  });
+});
+
+describe('parseCookieNames', () => {
+  it('returns names only, ignoring values', () => {
+    expect(parseCookieNames('a=1; b=2; c=3')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('handles values containing = signs', () => {
+    expect(parseCookieNames('token=base64==padding==')).toEqual(['token']);
+  });
+
+  it('trims whitespace around each name', () => {
+    expect(parseCookieNames('a=1 ;   b=2')).toEqual(['a', 'b']);
+  });
+
+  it('returns an empty array for an empty header', () => {
+    expect(parseCookieNames('')).toEqual([]);
+    expect(parseCookieNames('   ')).toEqual([]);
+  });
+
+  it('tolerates a valueless cookie segment', () => {
+    expect(parseCookieNames('a=1; flag; b=2')).toEqual(['a', 'flag', 'b']);
   });
 });

--- a/src/server/cookie-utils.ts
+++ b/src/server/cookie-utils.ts
@@ -7,3 +7,22 @@ export function parseCookies(cookieHeader: string): Record<string, string> {
     }),
   );
 }
+
+/**
+ * Parse only the cookie names from a `Cookie` header, skipping the values.
+ *
+ * Use this when you need the set of cookie names but not their contents — it
+ * avoids allocating the (potentially large) value strings that `parseCookies`
+ * materializes. Relevant on the PKCE-verifier eviction path, where the header
+ * can carry many large encrypted verifier blobs whose values are irrelevant.
+ */
+export function parseCookieNames(cookieHeader: string): string[] {
+  if (!cookieHeader.trim()) return [];
+  return cookieHeader
+    .split(';')
+    .map((cookie) => {
+      const eq = cookie.indexOf('=');
+      return (eq === -1 ? cookie : cookie.slice(0, eq)).trim();
+    })
+    .filter(Boolean);
+}

--- a/src/server/server-fn-bodies.ts
+++ b/src/server/server-fn-bodies.ts
@@ -6,6 +6,7 @@ import type {
 import { selectStalePKCEVerifierCookieNames } from '@workos/authkit-session';
 import { getRawAuthFromContext, mapAuthToBaseInfo, refreshSession, getRedirectUriFromContext } from './auth-helpers.js';
 import { getAuthkit } from './authkit-loader.js';
+import type { AuthKitServerContext } from './context.js';
 import { getInternalAuthKitContextOrNull } from './context.js';
 import { parseCookies } from './cookie-utils.js';
 import { emitHeadersFrom, forEachHeaderBagEntry } from './headers-bag.js';
@@ -40,7 +41,7 @@ async function forwardAuthorizationCookies(
     );
   }
 
-  await evictStalePendingVerifiers(authkit, result.cookieName);
+  await evictStalePendingVerifiers(ctx, authkit, result.cookieName);
 
   return result.url;
 }
@@ -63,12 +64,10 @@ async function forwardAuthorizationCookies(
  * new cookie itself uses.
  */
 async function evictStalePendingVerifiers(
+  ctx: AuthKitServerContext,
   authkit: AuthService<Request, Response>,
   keepCookieName: string,
 ): Promise<void> {
-  const ctx = getInternalAuthKitContextOrNull();
-  if (!ctx) return;
-
   const cookieHeader = ctx.request.headers.get('cookie');
   if (!cookieHeader) return;
 
@@ -76,14 +75,15 @@ async function evictStalePendingVerifiers(
   const stale = selectStalePKCEVerifierCookieNames(incomingNames, { keep: keepCookieName });
   if (stale.length === 0) return;
 
-  const redirectUri = getRedirectUriFromContext();
   // Each delete is independent, so fire them together and isolate per-cookie
   // failures with allSettled — a rejected clear just leaves an orphan to expire
   // on its TTL and must never block URL generation. (In this adapter each clear
   // only appends a Set-Cookie to the pending-header channel, so this is about
   // error isolation more than latency.)
   await Promise.allSettled(
-    stale.map((cookieName) => authkit.clearPendingVerifierByName(undefined, { cookieName, redirectUri })),
+    stale.map((cookieName) =>
+      authkit.clearPendingVerifierByName(undefined, { cookieName, redirectUri: ctx.redirectUri }),
+    ),
   );
 }
 

--- a/src/server/server-fn-bodies.ts
+++ b/src/server/server-fn-bodies.ts
@@ -77,13 +77,14 @@ async function evictStalePendingVerifiers(
   if (stale.length === 0) return;
 
   const redirectUri = getRedirectUriFromContext();
-  for (const cookieName of stale) {
-    try {
-      await authkit.clearPendingVerifierByName(undefined, { cookieName, redirectUri });
-    } catch {
-      // Hygiene cleanup is opportunistic — orphans expire on their own TTL.
-    }
-  }
+  // Each delete is independent, so fire them together and isolate per-cookie
+  // failures with allSettled — a rejected clear just leaves an orphan to expire
+  // on its TTL and must never block URL generation. (In this adapter each clear
+  // only appends a Set-Cookie to the pending-header channel, so this is about
+  // error isolation more than latency.)
+  await Promise.allSettled(
+    stale.map((cookieName) => authkit.clearPendingVerifierByName(undefined, { cookieName, redirectUri })),
+  );
 }
 
 /** Inject middleware-configured redirectUri only when caller did not provide one. */
@@ -159,13 +160,19 @@ export async function getAuthorizationUrlBody(options?: GetAuthURLOptions): Prom
 export async function getSignInUrlBody(data?: string | Omit<GetAuthURLOptions, 'screenHint'>): Promise<string> {
   const options = typeof data === 'string' ? { returnPathname: data } : data;
   const authkit = await getAuthkit();
-  return forwardAuthorizationCookies(authkit, await authkit.createSignIn(undefined, applyContextRedirectUri(options ?? {})));
+  return forwardAuthorizationCookies(
+    authkit,
+    await authkit.createSignIn(undefined, applyContextRedirectUri(options ?? {})),
+  );
 }
 
 export async function getSignUpUrlBody(data?: string | Omit<GetAuthURLOptions, 'screenHint'>): Promise<string> {
   const options = typeof data === 'string' ? { returnPathname: data } : data;
   const authkit = await getAuthkit();
-  return forwardAuthorizationCookies(authkit, await authkit.createSignUp(undefined, applyContextRedirectUri(options ?? {})));
+  return forwardAuthorizationCookies(
+    authkit,
+    await authkit.createSignUp(undefined, applyContextRedirectUri(options ?? {})),
+  );
 }
 
 export type SwitchToOrganizationPlan = { kind: 'redirect'; to: string } | { kind: 'user'; user: UserInfo };

--- a/src/server/server-fn-bodies.ts
+++ b/src/server/server-fn-bodies.ts
@@ -1,15 +1,17 @@
-import type { GetAuthorizationUrlOptions as GetAuthURLOptions, HeadersBag } from '@workos/authkit-session';
+import type {
+  AuthService,
+  CreateAuthorizationResult,
+  GetAuthorizationUrlOptions as GetAuthURLOptions,
+} from '@workos/authkit-session';
+import { selectStalePKCEVerifierCookieNames } from '@workos/authkit-session';
 import { getRawAuthFromContext, mapAuthToBaseInfo, refreshSession, getRedirectUriFromContext } from './auth-helpers.js';
 import { getAuthkit } from './authkit-loader.js';
 import { getInternalAuthKitContextOrNull } from './context.js';
+import { parseCookies } from './cookie-utils.js';
 import { emitHeadersFrom, forEachHeaderBagEntry } from './headers-bag.js';
 import type { NoUserInfo, UserInfo } from './server-functions.js';
 
-type AuthorizationResult = {
-  url: string;
-  response?: Response;
-  headers?: HeadersBag;
-};
+type AuthorizationResult = CreateAuthorizationResult<Response>;
 
 /**
  * Forward every `Set-Cookie` (and any other header) emitted by the upstream
@@ -18,7 +20,10 @@ type AuthorizationResult = {
  * is appended as its own header — never comma-joined — so multi-cookie
  * emissions survive as distinct HTTP headers.
  */
-function forwardAuthorizationCookies(result: AuthorizationResult): string {
+async function forwardAuthorizationCookies(
+  authkit: AuthService<Request, Response>,
+  result: AuthorizationResult,
+): Promise<string> {
   const ctx = getInternalAuthKitContextOrNull();
   if (!ctx?.__setPendingHeader) {
     throw new Error(
@@ -35,7 +40,50 @@ function forwardAuthorizationCookies(result: AuthorizationResult): string {
     );
   }
 
+  await evictStalePendingVerifiers(authkit, result.cookieName);
+
   return result.url;
+}
+
+/**
+ * Bound the number of pending PKCE verifier cookies.
+ *
+ * Each authorization-URL call mints a uniquely-named `wos-auth-verifier-*`
+ * cookie that never overwrites prior ones — per-flow naming exists so
+ * concurrent sign-ins (e.g. multiple tabs) don't clobber each other. The cost
+ * is that generating URLs without navigating to them (the `getSignInUrl()`-in-
+ * a-loader antipattern from issue #76) accumulates orphan cookies until their
+ * 10-minute TTL, eventually bloating the `Cookie` header into an HTTP 431.
+ *
+ * On the request that mints `keepCookieName`, evict every *other* verifier
+ * cookie once the running total would exceed the cap, keeping only the one
+ * just created. Best-effort: a cleanup failure must never break URL generation,
+ * so storage errors are swallowed. Deletes are emitted through middleware's
+ * pending-header channel via `clearPendingVerifierByName` — the same path the
+ * new cookie itself uses.
+ */
+async function evictStalePendingVerifiers(
+  authkit: AuthService<Request, Response>,
+  keepCookieName: string,
+): Promise<void> {
+  const ctx = getInternalAuthKitContextOrNull();
+  if (!ctx) return;
+
+  const cookieHeader = ctx.request.headers.get('cookie');
+  if (!cookieHeader) return;
+
+  const incomingNames = Object.keys(parseCookies(cookieHeader));
+  const stale = selectStalePKCEVerifierCookieNames(incomingNames, { keep: keepCookieName });
+  if (stale.length === 0) return;
+
+  const redirectUri = getRedirectUriFromContext();
+  for (const cookieName of stale) {
+    try {
+      await authkit.clearPendingVerifierByName(undefined, { cookieName, redirectUri });
+    } catch {
+      // Hygiene cleanup is opportunistic — orphans expire on their own TTL.
+    }
+  }
 }
 
 /** Inject middleware-configured redirectUri only when caller did not provide one. */
@@ -103,6 +151,7 @@ export function getAuthBody(): UserInfo | NoUserInfo {
 export async function getAuthorizationUrlBody(options?: GetAuthURLOptions): Promise<string> {
   const authkit = await getAuthkit();
   return forwardAuthorizationCookies(
+    authkit,
     await authkit.createAuthorization(undefined, applyContextRedirectUri(options ?? {})),
   );
 }
@@ -110,13 +159,13 @@ export async function getAuthorizationUrlBody(options?: GetAuthURLOptions): Prom
 export async function getSignInUrlBody(data?: string | Omit<GetAuthURLOptions, 'screenHint'>): Promise<string> {
   const options = typeof data === 'string' ? { returnPathname: data } : data;
   const authkit = await getAuthkit();
-  return forwardAuthorizationCookies(await authkit.createSignIn(undefined, applyContextRedirectUri(options ?? {})));
+  return forwardAuthorizationCookies(authkit, await authkit.createSignIn(undefined, applyContextRedirectUri(options ?? {})));
 }
 
 export async function getSignUpUrlBody(data?: string | Omit<GetAuthURLOptions, 'screenHint'>): Promise<string> {
   const options = typeof data === 'string' ? { returnPathname: data } : data;
   const authkit = await getAuthkit();
-  return forwardAuthorizationCookies(await authkit.createSignUp(undefined, applyContextRedirectUri(options ?? {})));
+  return forwardAuthorizationCookies(authkit, await authkit.createSignUp(undefined, applyContextRedirectUri(options ?? {})));
 }
 
 export type SwitchToOrganizationPlan = { kind: 'redirect'; to: string } | { kind: 'user'; user: UserInfo };

--- a/src/server/server-fn-bodies.ts
+++ b/src/server/server-fn-bodies.ts
@@ -8,23 +8,29 @@ import { getRawAuthFromContext, mapAuthToBaseInfo, refreshSession, getRedirectUr
 import { getAuthkit } from './authkit-loader.js';
 import type { AuthKitServerContext } from './context.js';
 import { getInternalAuthKitContextOrNull } from './context.js';
-import { parseCookies } from './cookie-utils.js';
+import { parseCookieNames } from './cookie-utils.js';
 import { emitHeadersFrom, forEachHeaderBagEntry } from './headers-bag.js';
 import type { NoUserInfo, UserInfo } from './server-functions.js';
 
 type AuthorizationResult = CreateAuthorizationResult<Response>;
 
 /**
- * Forward every `Set-Cookie` (and any other header) emitted by the upstream
- * authorization-URL call through middleware's pending-header channel so the
- * PKCE verifier cookie lands on the outgoing response. Each `Set-Cookie` entry
- * is appended as its own header — never comma-joined — so multi-cookie
- * emissions survive as distinct HTTP headers.
+ * Run the full authorization-URL pipeline: resolve the AuthKit service, invoke
+ * `create` to mint the URL + its PKCE verifier cookie, forward every emitted
+ * `Set-Cookie` through middleware's pending-header channel, evict stale verifier
+ * cookies, and return the URL.
+ *
+ * `create` names which flow to start (sign-in / sign-up / generic). The three
+ * URL server-function bodies differ only in that callback, so this pipeline
+ * lives here once. Each `Set-Cookie` is appended as its own header — never
+ * comma-joined — so a multi-cookie emission survives as distinct HTTP headers.
  */
-async function forwardAuthorizationCookies(
-  authkit: AuthService<Request, Response>,
-  result: AuthorizationResult,
+async function authorizationUrl(
+  create: (authkit: AuthService<Request, Response>) => Promise<AuthorizationResult>,
 ): Promise<string> {
+  const authkit = await getAuthkit();
+  const result = await create(authkit);
+
   const ctx = getInternalAuthKitContextOrNull();
   if (!ctx?.__setPendingHeader) {
     throw new Error(
@@ -71,8 +77,7 @@ async function evictStalePendingVerifiers(
   const cookieHeader = ctx.request.headers.get('cookie');
   if (!cookieHeader) return;
 
-  const incomingNames = Object.keys(parseCookies(cookieHeader));
-  const stale = selectStalePKCEVerifierCookieNames(incomingNames, { keep: keepCookieName });
+  const stale = selectStalePKCEVerifierCookieNames(parseCookieNames(cookieHeader), { keep: keepCookieName });
   if (stale.length === 0) return;
 
   // Each delete is independent, so fire them together and isolate per-cookie
@@ -149,29 +154,26 @@ export function getAuthBody(): UserInfo | NoUserInfo {
   return getAuthFromContext();
 }
 
-export async function getAuthorizationUrlBody(options?: GetAuthURLOptions): Promise<string> {
-  const authkit = await getAuthkit();
-  return forwardAuthorizationCookies(
-    authkit,
-    await authkit.createAuthorization(undefined, applyContextRedirectUri(options ?? {})),
+/** Normalize the sign-in/sign-up data arg: a bare string is the returnPathname. */
+function toAuthOptions(
+  data?: string | Omit<GetAuthURLOptions, 'screenHint'>,
+): Omit<GetAuthURLOptions, 'screenHint'> | undefined {
+  return typeof data === 'string' ? { returnPathname: data } : data;
+}
+
+export function getAuthorizationUrlBody(options?: GetAuthURLOptions): Promise<string> {
+  return authorizationUrl((authkit) => authkit.createAuthorization(undefined, applyContextRedirectUri(options ?? {})));
+}
+
+export function getSignInUrlBody(data?: string | Omit<GetAuthURLOptions, 'screenHint'>): Promise<string> {
+  return authorizationUrl((authkit) =>
+    authkit.createSignIn(undefined, applyContextRedirectUri(toAuthOptions(data) ?? {})),
   );
 }
 
-export async function getSignInUrlBody(data?: string | Omit<GetAuthURLOptions, 'screenHint'>): Promise<string> {
-  const options = typeof data === 'string' ? { returnPathname: data } : data;
-  const authkit = await getAuthkit();
-  return forwardAuthorizationCookies(
-    authkit,
-    await authkit.createSignIn(undefined, applyContextRedirectUri(options ?? {})),
-  );
-}
-
-export async function getSignUpUrlBody(data?: string | Omit<GetAuthURLOptions, 'screenHint'>): Promise<string> {
-  const options = typeof data === 'string' ? { returnPathname: data } : data;
-  const authkit = await getAuthkit();
-  return forwardAuthorizationCookies(
-    authkit,
-    await authkit.createSignUp(undefined, applyContextRedirectUri(options ?? {})),
+export function getSignUpUrlBody(data?: string | Omit<GetAuthURLOptions, 'screenHint'>): Promise<string> {
+  return authorizationUrl((authkit) =>
+    authkit.createSignUp(undefined, applyContextRedirectUri(toAuthOptions(data) ?? {})),
   );
 }
 

--- a/src/server/server-functions.spec.ts
+++ b/src/server/server-functions.spec.ts
@@ -11,12 +11,14 @@ const PKCE_COOKIE_NAME = getPKCECookieNameForState(SEALED_STATE_FIXTURE);
 
 const authorizationResult = (url: string) => ({
   url,
+  cookieName: PKCE_COOKIE_NAME,
   headers: {
     'Set-Cookie': `${PKCE_COOKIE_NAME}=${SEALED_STATE_FIXTURE}; Path=/; HttpOnly; SameSite=Lax; Max-Age=600; Secure`,
   },
 });
 
 const mockAuthkit = {
+  clearPendingVerifierByName: vi.fn().mockResolvedValue({}),
   withAuth: vi.fn(),
   getWorkOS: vi.fn(() => ({
     userManagement: {
@@ -35,6 +37,7 @@ const mockAuthkit = {
 
 const mockSetPendingHeader = vi.fn();
 let mockContextAvailable = true;
+let mockRequestCookieHeader: string | null = null;
 
 vi.mock('./authkit-loader', () => ({
   getAuthkit: vi.fn(() => Promise.resolve(mockAuthkit)),
@@ -97,9 +100,13 @@ vi.mock('@tanstack/react-start', () => ({
     if (!mockContextAvailable) {
       throw new Error('TanStack context not available');
     }
+    const headers = new Headers();
+    if (mockRequestCookieHeader) {
+      headers.set('cookie', mockRequestCookieHeader);
+    }
     return {
       auth: mockAuthContext,
-      request: new Request('http://test.local'),
+      request: new Request('http://test.local', { headers }),
       __setPendingHeader: mockSetPendingHeader,
     };
   },
@@ -115,6 +122,7 @@ describe('Server Functions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockContextAvailable = true;
+    mockRequestCookieHeader = null;
     mockAuthContext = () => ({ user: null });
   });
 
@@ -378,6 +386,67 @@ describe('Server Functions', () => {
         organizationId: 'org_456',
         loginHint: 'newuser@example.com',
       });
+    });
+  });
+
+  describe('PKCE verifier cookie eviction (issue #76)', () => {
+    const verifierName = (state: string) => getPKCECookieNameForState(state);
+    const cookieHeaderFor = (names: string[]) => names.map((n) => `${n}=x`).join('; ');
+
+    it('does not evict while pending verifiers stay within the cap', async () => {
+      mockRequestCookieHeader = cookieHeaderFor([
+        'wos-session', // non-verifier — must be ignored by the count
+        verifierName('a'),
+        verifierName('b'),
+        verifierName('c'),
+      ]);
+
+      await serverFunctions.getSignInUrl({ data: '/dashboard' });
+
+      expect(mockAuthkit.clearPendingVerifierByName).not.toHaveBeenCalled();
+    });
+
+    it('evicts every other verifier once the new cookie tips it over the cap', async () => {
+      const others = ['a', 'b', 'c', 'd', 'e'].map(verifierName); // 5 existing + 1 new = 6 > 5
+      mockRequestCookieHeader = cookieHeaderFor(others);
+
+      await serverFunctions.getSignInUrl({ data: '/dashboard' });
+
+      expect(mockAuthkit.clearPendingVerifierByName).toHaveBeenCalledTimes(others.length);
+      const clearedNames = mockAuthkit.clearPendingVerifierByName.mock.calls.map((c: any[]) => c[1].cookieName);
+      expect(new Set(clearedNames)).toEqual(new Set(others));
+      // The cookie minted by THIS request must never be evicted.
+      expect(clearedNames).not.toContain(PKCE_COOKIE_NAME);
+    });
+
+    it('does not delete the freshly minted cookie even when it is already on the request', async () => {
+      // keep + 4 others = 5 verifiers, within the cap → no eviction.
+      mockRequestCookieHeader = cookieHeaderFor([PKCE_COOKIE_NAME, ...['a', 'b', 'c', 'd'].map(verifierName)]);
+
+      await serverFunctions.getSignInUrl({ data: '/dashboard' });
+
+      expect(mockAuthkit.clearPendingVerifierByName).not.toHaveBeenCalled();
+    });
+
+    it('also evicts on getSignUpUrl and getAuthorizationUrl', async () => {
+      mockRequestCookieHeader = cookieHeaderFor(['a', 'b', 'c', 'd', 'e'].map(verifierName));
+
+      await serverFunctions.getSignUpUrl({ data: '/welcome' });
+      expect(mockAuthkit.clearPendingVerifierByName).toHaveBeenCalledTimes(5);
+
+      mockAuthkit.clearPendingVerifierByName.mockClear();
+      await serverFunctions.getAuthorizationUrl({ data: {} });
+      expect(mockAuthkit.clearPendingVerifierByName).toHaveBeenCalledTimes(5);
+    });
+
+    it('keeps generating the URL even when eviction fails', async () => {
+      mockAuthkit.createSignIn.mockResolvedValue(authorizationResult('https://auth.workos.com/resilient'));
+      mockRequestCookieHeader = cookieHeaderFor(['a', 'b', 'c', 'd', 'e'].map(verifierName));
+      mockAuthkit.clearPendingVerifierByName.mockRejectedValueOnce(new Error('storage boom'));
+
+      const url = await serverFunctions.getSignInUrl({ data: '/dashboard' });
+
+      expect(url).toBe('https://auth.workos.com/resilient');
     });
   });
 

--- a/src/server/server-functions.spec.ts
+++ b/src/server/server-functions.spec.ts
@@ -419,13 +419,16 @@ describe('Server Functions', () => {
       expect(clearedNames).not.toContain(PKCE_COOKIE_NAME);
     });
 
-    it('does not delete the freshly minted cookie even when it is already on the request', async () => {
-      // keep + 4 others = 5 verifiers, within the cap → no eviction.
-      mockRequestCookieHeader = cookieHeaderFor([PKCE_COOKIE_NAME, ...['a', 'b', 'c', 'd'].map(verifierName)]);
+    it('never deletes the freshly minted cookie, even when it is already on the request and over cap', async () => {
+      // keep + 5 others = 6 verifiers, over the cap → evict the others, spare `keep`.
+      const others = ['a', 'b', 'c', 'd', 'e'].map(verifierName);
+      mockRequestCookieHeader = cookieHeaderFor([PKCE_COOKIE_NAME, ...others]);
 
       await serverFunctions.getSignInUrl({ data: '/dashboard' });
 
-      expect(mockAuthkit.clearPendingVerifierByName).not.toHaveBeenCalled();
+      const clearedNames = mockAuthkit.clearPendingVerifierByName.mock.calls.map((c: any[]) => c[1].cookieName);
+      expect(new Set(clearedNames)).toEqual(new Set(others));
+      expect(clearedNames).not.toContain(PKCE_COOKIE_NAME);
     });
 
     it('also evicts on getSignUpUrl and getAuthorizationUrl', async () => {

--- a/src/server/server-functions.ts
+++ b/src/server/server-functions.ts
@@ -107,6 +107,15 @@ export const getAuth = createServerFn({ method: 'GET' }).handler(async (): Promi
 /**
  * Get the authorization URL for WorkOS authentication.
  * Supports different screen hints and return paths.
+ *
+ * @remarks
+ * **This has a side effect.** Each call starts a new OAuth (PKCE) flow and sets
+ * a short-lived `wos-auth-verifier-*` cookie. Invoke it on a user action or from
+ * a dedicated redirect route (e.g. `/api/auth/sign-in`) — do NOT prefetch it in
+ * a route `loader`/`beforeLoad` just to render a link. Generating URLs you never
+ * navigate to piles up verifier cookies. The SDK bounds the pile-up with
+ * automatic eviction, but the right pattern is still to call this only when the
+ * user is actually about to be redirected. See issue #76.
  */
 export const getAuthorizationUrl = createServerFn({ method: 'GET' })
   .inputValidator((options?: GetAuthURLOptions) => options)
@@ -130,6 +139,10 @@ export const getAuthorizationUrl = createServerFn({ method: 'GET' })
  * // With options
  * const url = await getSignInUrl({ data: { returnPathname: '/dashboard', state: 'custom-state' } });
  * ```
+ *
+ * @remarks
+ * Starts an OAuth flow and sets a PKCE verifier cookie — call on user action or
+ * from a redirect route, not prefetched in a loader for display. See issue #76.
  */
 export const getSignInUrl = createServerFn({ method: 'GET' })
   .inputValidator((data?: string | SignInUrlOptions) => data)
@@ -153,6 +166,10 @@ export const getSignInUrl = createServerFn({ method: 'GET' })
  * // With options
  * const url = await getSignUpUrl({ data: { returnPathname: '/dashboard', state: 'custom-state' } });
  * ```
+ *
+ * @remarks
+ * Starts an OAuth flow and sets a PKCE verifier cookie — call on user action or
+ * from a redirect route, not prefetched in a loader for display. See issue #76.
  */
 export const getSignUpUrl = createServerFn({ method: 'GET' })
   .inputValidator((data?: string | SignInUrlOptions) => data)


### PR DESCRIPTION
Closes #76.

## Problem

`getSignInUrl()` / `getSignUpUrl()` / `getAuthorizationUrl()` read like pure getters, but each call **starts an OAuth flow and sets a `wos-auth-verifier-<hash>` cookie**. The per-flow hashed name (so concurrent sign-ins across tabs don't clobber each other) means cookies never overwrite. Using these helpers to *display* a link — e.g. prefetching in a route `loader`, or calling unconditionally in `beforeLoad` even when already signed in — mints a fresh orphan cookie on every navigation. They pile up until the 10-minute PKCE TTL and eventually bloat the `Cookie` request header into an **HTTP 431**.

This is the consumer half of the fix; the shared primitive shipped in **`@workos/authkit-session@0.6.0`** (workos/authkit-session#42).

## Changes

- **Bump `@workos/authkit-session` → `^0.6.0`** (required for the new exports).
- **Bounded eviction in `server-fn-bodies.ts`.** After minting a verifier, parse the incoming `Cookie` header, compute stale verifier names via `selectStalePKCEVerifierCookieNames(names, { keep: result.cookieName })` (cap 5, all-but-newest), and clear each via `AuthService.clearPendingVerifierByName` through middleware's existing pending-`Set-Cookie` channel. **Best-effort** — wrapped so a cleanup failure can never break URL generation. Applies to all three helpers.
- **JSDoc warnings** on the public helpers in `server-functions.ts`: they have a cookie side effect and should be called on user action / from a redirect route, not prefetched in a loader for display.

The lazy body/shell boundary is preserved: the new `@workos/authkit-session` value import lives in `server-fn-bodies.ts` (a body file, already allowed to import server-only modules), reached only via the RPC-rewritten shell's dynamic `import()`.

## Why eviction (not just docs or "don't set a cookie")

- **Can't "return URL without a cookie":** PKCE requires the `codeVerifier` be persisted before the callback. The only cookie-free variant is the redirect-route pattern, which the example already uses.
- **Docs alone are insufficient:** the API shape invites the misuse (the Convex TanStack guide prefetches these in loaders). Eviction bounds the damage regardless of how the helper is called; the JSDoc steers people to the right pattern.
- **Mirrors `authkit-nextjs`** (`MAX_PKCE_COOKIES = 5`).

## Tests

- `server-functions.spec.ts` — 5 new cases: no eviction within cap; evict all-but-newest over cap; never evicts the freshly minted cookie (even if already on the request); applies to `getSignUpUrl`/`getAuthorizationUrl`; URL still generated when eviction throws.
- Full suite **227 passing**; `typecheck`, `lint`, SDK build, example build, and **`build:check` (no server-only fingerprints in the client bundle)** all clean against the published 0.6.0.

The example app already uses the recommended redirect-route pattern (`/api/auth/sign-in`), so no example change was needed.