### PR TITLE
fix!: require @workos-inc/node >=10.4.0 (eventemitter3 Vite dev crash #106)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "license": "MIT",
   "sideEffects": false,
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.11.0"
   },
   "homepage": "https://github.com/workos/authkit-tanstack-start#readme",
   "repository": {
@@ -70,6 +70,7 @@
   "peerDependencies": {
     "@tanstack/react-router": ">=1.0.0",
     "@tanstack/react-start": ">=1.168.25",
+    "@workos-inc/node": ">=10.4.0",
     "react": "^18.0 || ^19.0",
     "react-dom": "^18.0 || ^19.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@workos-inc/node':
+        specifier: '>=10.4.0'
+        version: 10.4.0
       '@workos/authkit-session':
         specifier: ^0.6.0
-        version: 0.6.0(@workos-inc/node@8.13.0)(typescript@5.9.3)
+        version: 0.6.0(@workos-inc/node@10.4.0)(typescript@5.9.3)
     devDependencies:
       '@tanstack/react-router':
         specifier: ^1.170.15
@@ -2132,9 +2135,9 @@ packages:
   '@vitest/utils@4.0.15':
     resolution: {integrity: sha512-HXjPW2w5dxhTD0dLwtYHDnelK3j8sR8cWIaLxr22evTyY6q8pRCjZSmhRWVjBaOVXChQd6AwMzi9pucorXCPZA==}
 
-  '@workos-inc/node@8.13.0':
-    resolution: {integrity: sha512-NgQKHpwh8AbT4KvAsW91Y+4f4jja2IvFPQ5atcy5NUxUMVRgXzRFEee3erawfXrTmiCVqJjd9PljHySKBXmHKQ==}
-    engines: {node: '>=20.15.0'}
+  '@workos-inc/node@10.4.0':
+    resolution: {integrity: sha512-mrrjFYQsYGbY/rGLqUN9IIwzoCa3aIg9gXViIRpzfXkH2mozJ1NBcxSivN3SpqLgoGDuyp3Wg3Mg5UgTJU4FYQ==}
+    engines: {node: '>=22.11.0'}
 
   '@workos/authkit-session@0.6.0':
     resolution: {integrity: sha512-AaDt34h4XF5BTF5ShN+W+8OOHxj+n0KmkX+e89OVNaeZJKwqao0b/S3m3BiAylNHdZGM95tsvRUKeoEXp5qERQ==}
@@ -2317,9 +2320,6 @@ packages:
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
-
-  eventemitter3@5.0.4:
-    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -4998,13 +4998,11 @@ snapshots:
       '@vitest/pretty-format': 4.0.15
       tinyrainbow: 3.0.3
 
-  '@workos-inc/node@8.13.0':
-    dependencies:
-      eventemitter3: 5.0.4
+  '@workos-inc/node@10.4.0': {}
 
-  '@workos/authkit-session@0.6.0(@workos-inc/node@8.13.0)(typescript@5.9.3)':
+  '@workos/authkit-session@0.6.0(@workos-inc/node@10.4.0)(typescript@5.9.3)':
     dependencies:
-      '@workos-inc/node': 8.13.0
+      '@workos-inc/node': 10.4.0
       iron-webcrypto: 2.0.0
       jose: 6.1.3
       valibot: 1.3.1(typescript@5.9.3)
@@ -5193,8 +5191,6 @@ snapshots:
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
-
-  eventemitter3@5.0.4: {}
 
   expect-type@1.3.0: {}
 


### PR DESCRIPTION
## Summary

Fixes #106. Pins the transitive `@workos-inc/node` peer floor to `>=10.4.0`, the version that removed `eventemitter3`.

## Root cause

The TanStack Start **client hydration entry imports the app's `src/start.ts`**, which imports `authkitMiddleware` from this package's main entry. In Vite **dev** there's no tree-shaking, so the whole server barrel — including its transitive `@workos/authkit-session` → `@workos-inc/node` chain — is eagerly evaluated in the browser. `@workos-inc/node` `8.11.1`–`10.3.x` bundled `eventemitter3`, whose CJS `index.js` (default-imported by its own `index.mjs`) cannot be served as raw ESM by Vite, so the browser throws:

```
Uncaught SyntaxError: The requested module '.../eventemitter3/index.js' does not provide an export named 'default' (at index.mjs:1:8)
```

`@workos-inc/node@10.4.0` replaced `eventemitter3` with an internal emitter, removing the landmine at the source.

## Why this fix

- The crash is in a **transitive** dependency; the cure is ensuring consumers resolve `@workos-inc/node >= 10.4.0`.
- This package doesn't import `@workos-inc/node` directly (it's `@workos/authkit-session`'s peer), so we declare the floor as a peer here to enforce it for consumers. It intersects with authkit-session's `^8 || ^9 || ^10` to an effective `>=10.4.0 <11`.
- `engines.node` bumped to `>=22.11.0` to match what `@workos-inc/node@10` requires (it dropped Node 20 in v9).

## Why this never reproduced in `example/`

`example/` consumes the SDK via a `workspace:*` symlink whose real path is **outside `node_modules`**, so Vite pre-bundles `@workos/authkit-session` with esbuild and fixes the CJS interop — masking the crash. A real install (npm/pnpm/bun) serves it raw and crashes. (The production `build`-based leak check can't catch this either — Rollup tree-shakes the prod bundle clean.)

## Breaking change

- Requires `@workos-inc/node >= 10.4.0`.
- Requires Node `>= 22.11`.

Consumers on an older `@workos-inc/node` / Node 20 will get a peer/engine warning prompting the upgrade.

## Test plan

- [x] `pnpm build` (typecheck + emit) — passes
- [x] `pnpm test` — 234 passing (incl. `exports.spec.ts`; error classes still exported from the main entry)
- [x] `cd example && pnpm build` — passes
- [x] `pnpm run build:check` — no server fingerprints in the client bundle
- [x] Reproduced #106 in a real Bun isolated install on `@workos-inc/node` < 10.4.0, and confirmed `>= 10.4.0` removes `eventemitter3` from the client module graph
