### PR TITLE
fix: update User test mocks for @workos-inc/node 10.4.0 (unblock publish)

### DIFF
--- a/src/client/AuthKitProvider.spec.tsx
+++ b/src/client/AuthKitProvider.spec.tsx
@@ -18,6 +18,7 @@ describe('AuthKitProvider', () => {
   const mockUser: User = {
     id: 'user_123',
     email: 'test@example.com',
+    name: 'Test User',
     firstName: 'Test',
     lastName: 'User',
     emailVerified: true,

--- a/src/client/useAccessToken.spec.tsx
+++ b/src/client/useAccessToken.spec.tsx
@@ -23,6 +23,7 @@ describe('useAccessToken', () => {
   const mockUser: User = {
     id: 'user_123',
     email: 'test@example.com',
+    name: 'Test User',
     firstName: 'Test',
     lastName: 'User',
     emailVerified: true,


### PR DESCRIPTION
## Summary

`0.10.0` was tagged by release-please but **failed to publish to npm** ([failed run](https://github.com/workos/authkit-tanstack-start/actions/runs/28126215224/job/83290622345)). The `Publish` job runs `prepublishOnly`, which includes `typecheck` (`tsc --noEmit`, root `tsconfig.json` — **includes spec files**), and it errored on two stale `User` mocks.

## Root cause

`#107` (`fix!: require @workos-inc/node >=10.4.0`) pulled in a node SDK where `User.name` (`string | null`) is **required**. Two test mocks predate that and omit `name`:

- `src/client/AuthKitProvider.spec.tsx`
- `src/client/useAccessToken.spec.tsx`

PR CI only runs `build` (`tsc -p tsconfig.build.json`, which **excludes** specs), so the error never surfaced on any PR — it only fired at publish time, leaving `0.10.0` tagged in git but absent from npm.

## Fix

Add the required `name` field to both `User` mocks. No runtime/source change.

## Verification

- `pnpm run typecheck` (root — the exact gate publish runs): **clean** ✅
- `pnpm run test`: 236 passing · `format:check` clean · `lint` clean

## Recommended follow-up (separate)

Add a `Typecheck` step to `ci.yml` so spec-only type errors are caught in PR CI rather than at publish (parity with `authkit-nextjs`, whose `ci.yml` already runs `typecheck`):

```yaml
      - name: Typecheck
        run: |
          pnpm run typecheck
```

I left this out of this PR (the workflow edit tripped a security guard, and it's cleanly separable from the release-unblock fix). Worth adding so this class of failure can't reach publish again.

## Re-publishing

A re-run of the failed job won't republish `0.10.0` (release-please won't re-tag it). Merging this `fix:` will have release-please cut **`0.10.1`**, and that release's publish job will run with the fix included.
