### PR TITLE
feat: add recent-auth checking (checkRecentAuth + useRecentAuth)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,78 +1,13 @@
 {
   "name": "@workos/authkit-tanstack-react-start",
-  "version": "0.10.1",
   "description": "The WorkOS library for TanStack React Start provides convenient helpers for authentication and session management using WorkOS & AuthKit with TanStack React Start.",
-  "type": "module",
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
-    },
-    "./client": {
-      "import": "./dist/client/index.js",
-      "types": "./dist/client/index.d.ts"
-    }
-  },
-  "files": [
-    "dist",
-    "LICENSE",
-    "README.md"
-  ],
-  "scripts": {
-    "clean": "rm -rf dist",
-    "dev": "tsc --watch",
-    "prebuild": "npm run clean",
-    "build": "tsc -p tsconfig.build.json",
-    "build:check": "scripts/check-bundle-leak.sh",
-    "prepublishOnly": "npm run build && npm run format:check && npm run lint && npm run typecheck && npm test && (cd example && pnpm build) && npm run build:check",
-    "typecheck": "tsc --noEmit",
-    "lint": "oxlint",
-    "format": "oxfmt .",
-    "format:check": "oxfmt --check .",
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "test:ui": "vitest --ui",
-    "test:coverage": "vitest run --coverage"
-  },
-  "keywords": [
-    "workos",
-    "authkit",
-    "authentication",
-    "auth",
-    "tanstack",
-    "tanstack-start",
-    "react-start",
-    "react",
-    "session",
-    "oauth",
-    "sso"
-  ],
+  "version": "0.10.1",
   "author": "WorkOS",
-  "license": "MIT",
-  "sideEffects": false,
-  "engines": {
-    "node": ">=22.11.0"
-  },
-  "homepage": "https://github.com/workos/authkit-tanstack-start#readme",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/workos/authkit-tanstack-start.git"
-  },
   "bugs": {
     "url": "https://github.com/workos/authkit-tanstack-start/issues"
   },
   "dependencies": {
-    "@workos/authkit-session": "^0.6.0"
-  },
-  "peerDependencies": {
-    "@tanstack/react-router": ">=1.0.0",
-    "@tanstack/react-start": ">=1.168.25",
-    "@workos-inc/node": ">=10.4.0",
-    "react": "^18.0 || ^19.0",
-    "react-dom": "^18.0 || ^19.0"
+    "@workos/authkit-session": "^0.7.0"
   },
   "devDependencies": {
     "@tanstack/react-router": "^1.170.15",
@@ -86,6 +21,7 @@
     "@types/react-dom": "^19.2.2",
     "@vitest/coverage-v8": "4.0.15",
     "@vitest/ui": "^4.0.15",
+    "@workos-inc/node": "^10.7.0",
     "happy-dom": "^20.0.11",
     "oxfmt": "^0.35.0",
     "oxlint": "^1.50.0",
@@ -95,10 +31,75 @@
     "typescript": "^5.9.3",
     "vitest": "^4.0.15"
   },
+  "engines": {
+    "node": ">=22.11.0"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./client": {
+      "types": "./dist/client/index.d.ts",
+      "import": "./dist/client/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md"
+  ],
+  "homepage": "https://github.com/workos/authkit-tanstack-start#readme",
+  "keywords": [
+    "auth",
+    "authentication",
+    "authkit",
+    "oauth",
+    "react",
+    "react-start",
+    "session",
+    "sso",
+    "tanstack",
+    "tanstack-start",
+    "workos"
+  ],
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "peerDependencies": {
+    "@tanstack/react-router": ">=1.0.0",
+    "@tanstack/react-start": ">=1.168.25",
+    "@workos-inc/node": ">=10.6.0",
+    "react": "^18.0 || ^19.0",
+    "react-dom": "^18.0 || ^19.0"
+  },
   "pnpm": {
     "onlyBuiltDependencies": [
       "@parcel/watcher",
       "esbuild"
     ]
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/workos/authkit-tanstack-start.git"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "build:check": "scripts/check-bundle-leak.sh",
+    "clean": "rm -rf dist",
+    "dev": "tsc --watch",
+    "format": "oxfmt .",
+    "format:check": "oxfmt --check .",
+    "lint": "oxlint",
+    "prebuild": "npm run clean",
+    "prepublishOnly": "npm run build && npm run format:check && npm run lint && npm run typecheck && npm test && (cd example && pnpm build) && npm run build:check",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:ui": "vitest --ui",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "sideEffects": false,
+  "type": "module",
+  "types": "./dist/index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "peerDependencies": {
     "@tanstack/react-router": ">=1.0.0",
     "@tanstack/react-start": ">=1.168.25",
-    "@workos-inc/node": ">=10.6.0",
+    "@workos-inc/node": "^10.7.0",
     "react": "^18.0 || ^19.0",
     "react-dom": "^18.0 || ^19.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,9 @@ importers:
 
   .:
     dependencies:
-      '@workos-inc/node':
-        specifier: '>=10.4.0'
-        version: 10.4.0
       '@workos/authkit-session':
-        specifier: ^0.6.0
-        version: 0.6.0(@workos-inc/node@10.4.0)(typescript@5.9.3)
+        specifier: ^0.7.0
+        version: 0.7.0(@workos-inc/node@10.7.0)(typescript@5.9.3)
     devDependencies:
       '@tanstack/react-router':
         specifier: ^1.170.15
@@ -48,6 +45,9 @@ importers:
       '@vitest/ui':
         specifier: ^4.0.15
         version: 4.0.15(vitest@4.0.15)
+      '@workos-inc/node':
+        specifier: ^10.7.0
+        version: 10.7.0
       happy-dom:
         specifier: ^20.0.11
         version: 20.8.9
@@ -643,48 +643,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.35.0':
     resolution: {integrity: sha512-5Okqi+uhYFxwKz8hcnUftNNwdm8BCkf6GSCbcz9xJxYMm87k1E4p7PEmAAbhLTk7cjSdDre6TDL0pDzNX+Y22Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.35.0':
     resolution: {integrity: sha512-9k66pbZQXM/lBJWys3Xbc5yhl4JexyfqkEf/tvtq8976VIJnLAAL3M127xHA3ifYSqxdVHfVGTg84eiBHCGcNw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.35.0':
     resolution: {integrity: sha512-aUcY9ofKPtjO52idT6t0SAQvEF6ctjzUQa1lLp7GDsRpSBvuTrBQGeq0rYKz3gN8dMIQ7mtMdGD9tT4LhR8jAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.35.0':
     resolution: {integrity: sha512-C6yhY5Hvc2sGM+mCPek9ZLe5xRUOC/BvhAt2qIWFAeXMn4il04EYIjl3DsWiJr0xDMTJhvMOmD55xTRPlNp39w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.35.0':
     resolution: {integrity: sha512-RG2hlvOMK4OMZpO3mt8MpxLQ0AAezlFqhn5mI/g5YrVbPFyoCv9a34AAvbSJS501ocOxlFIRcKEuw5hFvddf9g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.35.0':
     resolution: {integrity: sha512-wzmh90Pwvqj9xOKHJjkQYBpydRkaXG77ZvDz+iFDRRQpnqIEqGm5gmim2s6vnZIkDGsvKCuTdtxm0GFmBjM1+w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.35.0':
     resolution: {integrity: sha512-+HCqYCJPCUy5I+b2cf+gUVaApfgtoQT3HdnSg/l7NIcLHOhKstlYaGyrFZLmUpQt4WkFbpGKZZayG6zjRU0KFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.35.0':
     resolution: {integrity: sha512-kFYmWfR9YL78XyO5ws+1dsxNvZoD973qfVMNFOS4e9bcHXGF7DvGC2tY5UDFwyMCeB33t3sDIuGONKggnVNSJA==}
@@ -757,48 +765,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.53.0':
     resolution: {integrity: sha512-GXI1o4Thn/rtnRIL38BwrDMwVcUbIHKCsOixIWf/CkU3fCG3MXFzFTtDMt+34ik0Qk452d8kcpksL0w/hUkMZA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.53.0':
     resolution: {integrity: sha512-Uahk7IVs2yBamCgeJ3XKpKT9Vh+de0pDKISFKnjEcI3c/w2CFHk1+W6Q6G3KI56HGwE9PWCp6ayhA9whXWkNIQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.53.0':
     resolution: {integrity: sha512-sWtcU9UkrKMWsGKdFy8R6jkm9Q0VVG1VCpxVuh0HzRQQi3ENI1Nh5CkpsdfUs2MKRcOoHKbXqTscunuXjhxoxQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.53.0':
     resolution: {integrity: sha512-aXew1+HDvCdExijX/8NBVC854zJwxhKP3l9AHFSHQNo4EanlHtzDMIlIvP3raUkL0vXtFCkTFYezzU5HjstB8A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.53.0':
     resolution: {integrity: sha512-rVpyBSqPGou9sITcsoXqUoGBUH74bxYLYOAGUqN599Zu6BQBlBU9hh3bJQ/20D1xrhhrsbiCpVPvXpLPM5nL1w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.53.0':
     resolution: {integrity: sha512-eOyeQ8qFQ2geXmlWJuXAOaek0hFhbMLlYsU457NMLKDRoC43Xf+eDPZ9Yk0n9jDaGJ5zBl/3Dy8wo41cnIXuLA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.53.0':
     resolution: {integrity: sha512-S6rBArW/zD1tob8M9PwKYrRmz+j1ss1+wjbRAJCWKd7TC3JB6noDiA95pIj9zOZVVp04MIzy5qymnYusrEyXzg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.53.0':
     resolution: {integrity: sha512-sd/A0Ny5sN0D/MJtlk7w2jGY4bJQou7gToa9WZF7Sj6HTyVzvlzKJWiOHfr4SulVk4ndiFQ8rKmF9rXP0EcF3A==}
@@ -1568,36 +1584,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
@@ -1689,121 +1711,145 @@ packages:
     resolution: {integrity: sha512-UPMMNeC4LXW7ZSHxeP3Edv09aLsFUMaD1TSVW6n1CWMECnUIJMFFB7+XC2lZTdPtvB36tYC0cJWc86mzSsaviw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.4':
     resolution: {integrity: sha512-H8uwlV0otHs5Q7WAMSoyvjV9DJPiy5nJ/xnHolY0QptLPjaSsuX7tw+SPIfiYH6cnVx3fe4EWFafo6gH6ekZKA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.53.4':
     resolution: {integrity: sha512-BLRwSRwICXz0TXkbIbqJ1ibK+/dSBpTJqDClF61GWIrxTXZWQE78ROeIhgl5MjVs4B4gSLPCFeD4xML9vbzvCQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.53.4':
     resolution: {integrity: sha512-6bySEjOTbmVcPJAywjpGLckK793A0TJWSbIa0sVwtVGfe/Nz6gOWHOwkshUIAp9j7wg2WKcA4Snu7Y1nUZyQew==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.53.4':
     resolution: {integrity: sha512-U0ow3bXYJZ5MIbchVusxEycBw7bO6C2u5UvD31i5IMTrnt2p4Fh4ZbHSdc/31TScIJQYHwxbj05BpevB3201ug==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.4':
     resolution: {integrity: sha512-iujDk07ZNwGLVn0YIWM80SFN039bHZHCdCCuX9nyx3Jsa2d9V/0Y32F+YadzwbvDxhSeVo9zefkoPnXEImnM5w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.4':
     resolution: {integrity: sha512-MUtAktiOUSu+AXBpx1fkuG/Bi5rhlorGs3lw5QeJ2X3ziEGAq7vFNdWVde6XGaVqi0LGSvugwjoxSNJfHFTC0g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.53.4':
     resolution: {integrity: sha512-btm35eAbDfPtcFEgaXCI5l3c2WXyzwiE8pArhd66SDtoLWmgK5/M7CUxmUglkwtniPzwvWioBKKl6IXLbPf2sQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.53.4':
     resolution: {integrity: sha512-uJlhKE9ccUTCUlK+HUz/80cVtx2RayadC5ldDrrDUFaJK0SNb8/cCmC9RhBhIWuZ71Nqj4Uoa9+xljKWRogdhA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.53.4':
     resolution: {integrity: sha512-jjEMkzvASQBbzzlzf4os7nzSBd/cvPrpqXCUOqoeCh1dQ4BP3RZCJk8XBeik4MUln3m+8LeTJcY54C/u8wb3DQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.53.4':
     resolution: {integrity: sha512-lu90KG06NNH19shC5rBPkrh6mrTpq5kviFylPBXQVpdEu0yzb0mDgyxLr6XdcGdBIQTH/UAhDJnL+APZTBu1aQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -2135,12 +2181,12 @@ packages:
   '@vitest/utils@4.0.15':
     resolution: {integrity: sha512-HXjPW2w5dxhTD0dLwtYHDnelK3j8sR8cWIaLxr22evTyY6q8pRCjZSmhRWVjBaOVXChQd6AwMzi9pucorXCPZA==}
 
-  '@workos-inc/node@10.4.0':
-    resolution: {integrity: sha512-mrrjFYQsYGbY/rGLqUN9IIwzoCa3aIg9gXViIRpzfXkH2mozJ1NBcxSivN3SpqLgoGDuyp3Wg3Mg5UgTJU4FYQ==}
+  '@workos-inc/node@10.7.0':
+    resolution: {integrity: sha512-rffa9znZuIv4yo+9JRxGOLTTSxh0XhOT6jlsktgqEi9MuB9V0VFHRzLd3bTpkq+J9sgrPZNGpvX4aWNfMqt5cQ==}
     engines: {node: '>=22.11.0'}
 
-  '@workos/authkit-session@0.6.0':
-    resolution: {integrity: sha512-AaDt34h4XF5BTF5ShN+W+8OOHxj+n0KmkX+e89OVNaeZJKwqao0b/S3m3BiAylNHdZGM95tsvRUKeoEXp5qERQ==}
+  '@workos/authkit-session@0.7.0':
+    resolution: {integrity: sha512-8RvHzszR3Z6k8w+5m47G3B4ultZljRw9pLyCyEPtAg6+7gBdDEIt/0f9TNBOZdvlIz4YHIechUzYujdmR20ngA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@workos-inc/node': ^8.0.0 || ^9.0.0 || ^10.0.0
@@ -2496,24 +2542,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2869,6 +2919,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -4998,11 +5049,11 @@ snapshots:
       '@vitest/pretty-format': 4.0.15
       tinyrainbow: 3.0.3
 
-  '@workos-inc/node@10.4.0': {}
+  '@workos-inc/node@10.7.0': {}
 
-  '@workos/authkit-session@0.6.0(@workos-inc/node@10.4.0)(typescript@5.9.3)':
+  '@workos/authkit-session@0.7.0(@workos-inc/node@10.7.0)(typescript@5.9.3)':
     dependencies:
-      '@workos-inc/node': 10.4.0
+      '@workos-inc/node': 10.7.0
       iron-webcrypto: 2.0.0
       jose: 6.1.3
       valibot: 1.3.1(typescript@5.9.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 packages:
   - '.'
   - example/
+allowBuilds:
+  esbuild: true

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -8,6 +8,7 @@ export { AuthKitProvider, useAuth } from './AuthKitProvider.js';
 export { Impersonation } from './components/impersonation.js';
 export { useAccessToken } from './useAccessToken.js';
 export { useTokenClaims } from './useTokenClaims.js';
+export { useRecentAuth } from './useRecentAuth.js';
 
 export { getAuthAction } from '../server/actions.js';
 

--- a/src/client/jwt.ts
+++ b/src/client/jwt.ts
@@ -36,11 +36,11 @@ export interface JWTPayload {
    */
   aud?: string | string[];
   /**
-   * Expiration time of the JWT, represented as a Unix timestamp
+   * Expiration time of the JWT, represented as epoch seconds
    */
   exp: number;
   /**
-   * Issued at time of the JWT, represented as a Unix timestamp
+   * Issued at time of the JWT, represented as epoch seconds
    */
   iat: number;
   /**
@@ -67,6 +67,11 @@ export interface JWTPayload {
    * Permissions granted to the user associated with the JWT
    */
   permissions?: string[];
+
+  /**
+   * Time of user authentication, represented as epoch seconds
+   */
+  auth_time?: number;
 }
 
 export type TokenClaims<T> = Partial<JWTPayload & T>;

--- a/src/client/useRecentAuth.spec.tsx
+++ b/src/client/useRecentAuth.spec.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useRecentAuth } from './useRecentAuth';
+import { useAccessToken } from './useAccessToken';
+import { useTokenClaims } from './useTokenClaims';
+
+vi.mock('./useAccessToken');
+vi.mock('./useTokenClaims');
+
+const NOW_MS = 1_700_000_000_000;
+const NOW_S = NOW_MS / 1000;
+
+function mockAccessToken(loading: boolean) {
+  vi.mocked(useAccessToken).mockReturnValue({
+    accessToken: undefined,
+    loading,
+    error: null,
+    refresh: vi.fn(),
+    getAccessToken: vi.fn(),
+  });
+}
+
+describe('useRecentAuth', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW_MS);
+    mockAccessToken(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('reports recent auth as not stale', () => {
+    vi.mocked(useTokenClaims).mockReturnValue({ auth_time: NOW_S - 60 });
+
+    const { result } = renderHook(() => useRecentAuth({ maxAge: 300 }));
+
+    expect(result.current.isStale).toBe(false);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.authenticatedAt).toEqual(new Date((NOW_S - 60) * 1000));
+  });
+
+  it('reports stale auth past maxAge', () => {
+    vi.mocked(useTokenClaims).mockReturnValue({ auth_time: NOW_S - 600 });
+
+    const { result } = renderHook(() => useRecentAuth({ maxAge: 300 }));
+
+    expect(result.current.isStale).toBe(true);
+  });
+
+  it('fails closed when auth_time is absent', () => {
+    vi.mocked(useTokenClaims).mockReturnValue({});
+
+    const { result } = renderHook(() => useRecentAuth({ maxAge: 300 }));
+
+    expect(result.current.isStale).toBe(true);
+    expect(result.current.authenticatedAt).toBeNull();
+  });
+
+  it('surfaces the token loading state', () => {
+    mockAccessToken(true);
+    vi.mocked(useTokenClaims).mockReturnValue({});
+
+    const { result } = renderHook(() => useRecentAuth({ maxAge: 300 }));
+
+    expect(result.current.loading).toBe(true);
+  });
+});

--- a/src/client/useRecentAuth.ts
+++ b/src/client/useRecentAuth.ts
@@ -1,0 +1,29 @@
+import { evaluateRecentAuth } from '../internal/recent-auth.js';
+import { useAccessToken } from './useAccessToken.js';
+import { useTokenClaims } from './useTokenClaims.js';
+
+/**
+ * Reports how recently the current user authenticated, from the `auth_time`
+ * claim already held in client memory. Presentation only — enforce recency
+ * server-side with `checkRecentAuth`.
+ */
+export function useRecentAuth({ maxAge }: { maxAge: number }) {
+  const { loading } = useAccessToken();
+  const { auth_time } = useTokenClaims();
+
+  if (loading) {
+    return {
+      loading: true,
+      authenticatedAt: undefined,
+      isStale: undefined,
+    } as const;
+  }
+
+  const recentAuth = evaluateRecentAuth({
+    authTime: auth_time,
+    maxAgeSeconds: maxAge,
+    nowSeconds: Math.floor(Date.now() / 1000),
+  });
+
+  return { ...recentAuth, loading } as const;
+}

--- a/src/internal/recent-auth.spec.ts
+++ b/src/internal/recent-auth.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateRecentAuth } from './recent-auth';
+
+const NOW = 1_700_000_000; // fixed epoch seconds
+
+describe('evaluateRecentAuth', () => {
+  it('reports recent auth as not stale', () => {
+    const authTime = NOW - 60; // 1 minute ago
+    const result = evaluateRecentAuth({ authTime, maxAgeSeconds: 300, nowSeconds: NOW });
+
+    expect(result.isStale).toBe(false);
+    expect(result.authenticatedAt).toEqual(new Date(authTime * 1000));
+  });
+
+  it('reports auth older than maxAge as stale', () => {
+    const authTime = NOW - 600; // 10 minutes ago
+    const result = evaluateRecentAuth({ authTime, maxAgeSeconds: 300, nowSeconds: NOW });
+
+    expect(result.isStale).toBe(true);
+    expect(result.authenticatedAt).toEqual(new Date(authTime * 1000));
+  });
+
+  it('treats exactly maxAge as not stale (boundary is inclusive)', () => {
+    const result = evaluateRecentAuth({ authTime: NOW - 300, maxAgeSeconds: 300, nowSeconds: NOW });
+    expect(result.isStale).toBe(false);
+  });
+
+  it('fails closed when auth_time is missing', () => {
+    expect(evaluateRecentAuth({ authTime: undefined, maxAgeSeconds: 300, nowSeconds: NOW })).toEqual({
+      authenticatedAt: null,
+      isStale: true,
+    });
+  });
+
+  it('fails closed when auth_time is not a finite number', () => {
+    for (const bad of ['1700000000', NaN, Infinity, null, {}]) {
+      expect(evaluateRecentAuth({ authTime: bad, maxAgeSeconds: 300, nowSeconds: NOW })).toEqual({
+        authenticatedAt: null,
+        isStale: true,
+      });
+    }
+  });
+
+  it('does not treat future auth_time (clock skew) as stale', () => {
+    const result = evaluateRecentAuth({ authTime: NOW + 30, maxAgeSeconds: 300, nowSeconds: NOW });
+    expect(result.isStale).toBe(false);
+  });
+});

--- a/src/internal/recent-auth.ts
+++ b/src/internal/recent-auth.ts
@@ -1,0 +1,22 @@
+type EvaluateRecentAuthParameters = {
+  authTime: unknown;
+  maxAgeSeconds: number;
+  nowSeconds: number;
+};
+
+/**
+ * Evaluate whether an authentication is recent enough.
+ */
+export function evaluateRecentAuth({ authTime, maxAgeSeconds, nowSeconds }: EvaluateRecentAuthParameters) {
+  if (typeof authTime !== 'number' || !Number.isFinite(authTime)) {
+    return {
+      authenticatedAt: null,
+      isStale: true,
+    } as const;
+  }
+
+  return {
+    authenticatedAt: new Date(authTime * 1000),
+    isStale: nowSeconds - authTime > maxAgeSeconds,
+  } as const;
+}

--- a/src/server/check-recent-auth.spec.ts
+++ b/src/server/check-recent-auth.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+let mockAuth: any = { user: null };
+
+vi.mock('./auth-helpers', () => ({
+  getRawAuthFromContext: () => mockAuth,
+}));
+
+import { checkRecentAuthBody } from './server-fn-bodies';
+
+const NOW_MS = 1_700_000_000_000;
+const NOW_S = NOW_MS / 1000;
+
+const authenticated = (authTime?: number) => ({
+  user: { id: 'user_123' },
+  sessionId: 'session_123',
+  accessToken: 'token',
+  claims: { sid: 'session_123', auth_time: authTime },
+});
+
+describe('checkRecentAuthBody', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW_MS);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reports recent auth as not stale', () => {
+    mockAuth = authenticated(NOW_S - 60);
+    const result = checkRecentAuthBody({ maxAge: 300 });
+
+    expect(result.isStale).toBe(false);
+    expect(result.authenticatedAt).toEqual(new Date((NOW_S - 60) * 1000));
+  });
+
+  it('reports stale auth past maxAge', () => {
+    mockAuth = authenticated(NOW_S - 600);
+    expect(checkRecentAuthBody({ maxAge: 300 }).isStale).toBe(true);
+  });
+
+  it('fails closed when auth_time claim is missing', () => {
+    mockAuth = authenticated(undefined);
+    expect(checkRecentAuthBody({ maxAge: 300 })).toEqual({ authenticatedAt: null, isStale: true });
+  });
+
+  it('fails closed when there is no authenticated user', () => {
+    mockAuth = { user: null };
+    expect(checkRecentAuthBody({ maxAge: 300 })).toEqual({ authenticatedAt: null, isStale: true });
+  });
+});

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -3,6 +3,7 @@ export {
   type NoUserInfo,
   type GetAuthURLOptions,
   getAuth,
+  checkRecentAuth,
   signOut,
   switchToOrganization,
   getAuthorizationUrl,

--- a/src/server/server-fn-bodies.ts
+++ b/src/server/server-fn-bodies.ts
@@ -4,6 +4,7 @@ import type {
   GetAuthorizationUrlOptions as GetAuthURLOptions,
 } from '@workos/authkit-session';
 import { selectStalePKCEVerifierCookieNames } from '@workos/authkit-session';
+import { evaluateRecentAuth } from '../internal/recent-auth.js';
 import { getRawAuthFromContext, mapAuthToBaseInfo, refreshSession, getRedirectUriFromContext } from './auth-helpers.js';
 import { getAuthkit } from './authkit-loader.js';
 import type { AuthKitServerContext } from './context.js';
@@ -152,6 +153,12 @@ export async function signOutBody(data?: { returnTo?: string }): Promise<SignOut
 
 export function getAuthBody(): UserInfo | NoUserInfo {
   return getAuthFromContext();
+}
+
+export function checkRecentAuthBody({ maxAge }: { maxAge: number }) {
+  const auth = getRawAuthFromContext();
+  const authTime = auth.user ? auth.claims?.auth_time : undefined;
+  return evaluateRecentAuth({ authTime, maxAgeSeconds: maxAge, nowSeconds: Math.floor(Date.now() / 1000) });
 }
 
 /** Normalize the sign-in/sign-up data arg: a bare string is the returnPathname. */

--- a/src/server/server-functions.ts
+++ b/src/server/server-functions.ts
@@ -105,6 +105,36 @@ export const getAuth = createServerFn({ method: 'GET' }).handler(async (): Promi
 });
 
 /**
+ * Check how recently the current user authenticated, using the `auth_time`
+ * claim on the access token. Returns data only — it never redirects — so it is
+ * safe to call as the enforcement step inside a sensitive server action or in a
+ * loader where you decide what to do.
+ *
+ * Fails closed: a session with no usable `auth_time` (or no user) is reported
+ * as `isStale: true`.
+ *
+ * @example
+ * ```typescript
+ * // Guard a sensitive server action
+ * const { isStale } = await checkRecentAuth({ data: { maxAge: 300 } });
+ * if (isStale) {
+ *   return { status: 'reauth_required' };
+ * }
+ * ```
+ *
+ * @remarks
+ * To send the user through re-authentication, redirect to your sign-in route
+ * with `maxAge` (e.g. `getSignInUrl({ data: { maxAge: 300 } })`), which forwards
+ * OIDC `max_age` so the IdP forces a reauth when most recent auth is older.
+ */
+export const checkRecentAuth = createServerFn({ method: 'GET' })
+  .validator((options: { maxAge: number }) => options)
+  .handler(async ({ data }) => {
+    const { checkRecentAuthBody } = await import('./server-fn-bodies.js');
+    return checkRecentAuthBody(data);
+  });
+
+/**
  * Get the authorization URL for WorkOS authentication.
  * Supports different screen hints and return paths.
  *

--- a/tests/exports.spec.ts
+++ b/tests/exports.spec.ts
@@ -5,6 +5,7 @@ describe('SDK exports', () => {
   it('exports expected functions', () => {
     // Server functions
     expect(exports.getAuth).toBeDefined();
+    expect(exports.checkRecentAuth).toBeDefined();
     expect(exports.signOut).toBeDefined();
     expect(exports.switchToOrganization).toBeDefined();
     expect(exports.getAuthorizationUrl).toBeDefined();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
           name: 'server',
           globals: true,
           environment: 'node',
-          include: ['src/server/**/*.spec.{ts,tsx}', 'tests/**/*.spec.{ts,tsx}'],
+          include: ['src/internal/**/*.spec.{ts,tsx}', 'src/server/**/*.spec.{ts,tsx}', 'tests/**/*.spec.{ts,tsx}'],
           setupFiles: ['./tests/setup-server.ts'],
         },
       },


### PR DESCRIPTION
Surface the access token's `auth_time` claim so apps can enforce step-up / reauthentication.

## What's in here

- **`checkRecentAuth` server function** — data-only recency check that fails closed (`isStale: true` when `auth_time` is missing or there's no user). Safe to call as the enforcement step in a sensitive action or loader.
- **`useRecentAuth` client hook** — presentation-only recency state from claims already in client memory.
- **`evaluateRecentAuth`** — shared internal helper backing both.
- Added `auth_time` to `JWTPayload`.

## Dependencies

- Requires `@workos/authkit-session` `^0.7.0`.
- Peer `@workos-inc/node` floor bumped to `>=10.6.0`.